### PR TITLE
Feature(domain): 도메인 모델(AccessLog, IpInfo, AnalysisResult) 구현

### DIFF
--- a/src/main/java/com/electricip/loganalyzer/domain/AccessLog.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/AccessLog.java
@@ -1,0 +1,48 @@
+package com.electricip.loganalyzer.domain;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+/**
+ * 접속 로그 도메인 모델
+ */
+public record AccessLog(
+    LocalDateTime timeGenerated,
+    String clientIp,
+    String httpMethod,
+    String requestUri,
+    String userAgent,
+    Integer httpStatus,
+    String httpVersion,
+    Long receivedBytes,
+    Long sentBytes,
+    Double clientResponseTime,
+    String sslProtocol,
+    String originalRequestUriWithArgs
+) {
+    /**
+     * 매개변수 유효성 검사
+     */
+    public AccessLog {
+        // null 허용 (Optional 필드)
+    }
+    
+    /**
+     * 비즈니스 로직: 성공 여부
+     */
+    public boolean isSuccessful() {
+        return httpStatus != null && httpStatus >= 200 && httpStatus < 300;
+    }
+    
+    /**
+     * 비즈니스 로직: 상태 코드 카테고리
+     */
+    public String statusCategory() {
+        if (httpStatus == null) return "Unknown";
+        if (httpStatus >= 200 && httpStatus < 300) return "2xx";
+        if (httpStatus >= 300 && httpStatus < 400) return "3xx";
+        if (httpStatus >= 400 && httpStatus < 500) return "4xx";
+        if (httpStatus >= 500 && httpStatus < 600) return "5xx";
+        return "Unknown";
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/domain/AnalysisResult.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/AnalysisResult.java
@@ -1,0 +1,126 @@
+package com.electricip.loganalyzer.domain;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 분석 결과 Aggregate
+ */
+@Value
+@Builder
+public class AnalysisResult {
+    String analysisId;
+    LocalDateTime completedAt;
+    Long processingTimeMs;
+    
+    Statistics statistics;
+    @Builder.Default
+    Map<String, IpInfo> ipDetails = Collections.emptyMap();
+    @Builder.Default
+    ParseErrors parseErrors = ParseErrors.empty();
+    
+    /**
+     * 통계 Value Object
+     */
+    @Value
+    @Builder
+    public static class Statistics {
+        long totalRequests;
+        long successCount;
+        long redirectCount;
+        long clientErrorCount;
+        long serverErrorCount;
+        
+        @Builder.Default
+        List<TopItem> topPaths = Collections.emptyList();
+        @Builder.Default
+        List<TopItem> topStatusCodes = Collections.emptyList();
+        @Builder.Default
+        List<TopItem> topIps = Collections.emptyList();
+        
+        @Builder.Default
+        Map<String, Long> methodStats = Collections.emptyMap();
+        double avgResponseTime;
+        double avgSentBytes;
+        long totalTraffic;
+        
+        /**
+         * 도메인 로직: 비율 계산
+         */
+        public double successRate() {
+            return calculateRate(successCount);
+        }
+        
+        public double redirectRate() {
+            return calculateRate(redirectCount);
+        }
+        
+        public double clientErrorRate() {
+            return calculateRate(clientErrorCount);
+        }
+        
+        public double serverErrorRate() {
+            return calculateRate(serverErrorCount);
+        }
+        
+        private double calculateRate(long count) {
+            if (totalRequests == 0) return 0.0;
+            return Math.round((count * 100.0 / totalRequests) * 100.0) / 100.0;
+        }
+        
+        /**
+         * 가변 컬렉션 반환 시 불변 뷰 제공
+         */
+        public List<TopItem> getTopPaths() {
+            return Collections.unmodifiableList(topPaths);
+        }
+        
+        public List<TopItem> getTopIps() {
+            return Collections.unmodifiableList(topIps);
+        }
+        
+        public Map<String, Long> getMethodStats() {
+            return Collections.unmodifiableMap(methodStats);
+        }
+    }
+    
+    /**
+     * Top Item (Record)
+     */
+    public record TopItem(String item, long count) {
+        public TopItem {
+            if (item == null) {
+                throw new IllegalArgumentException("item은 null일 수 없습니다");
+            }
+            if (count < 0) {
+                throw new IllegalArgumentException("count는 음수일 수 없습니다");
+            }
+        }
+    }
+    
+    /**
+     * 파싱 오류 (Record)
+     */
+    public record ParseErrors(int errorCount, List<String> errorSamples) {
+        public static ParseErrors empty() {
+            return new ParseErrors(0, Collections.emptyList());
+        }
+
+        public ParseErrors {
+            errorSamples = List.copyOf(errorSamples);
+        }
+
+        public List<String> errorSamples() {
+            return errorSamples; // 이미 불변
+        }
+    }
+
+    public Map<String, IpInfo> getIpDetails() {
+        return Collections.unmodifiableMap(ipDetails);
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/domain/IpInfo.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/IpInfo.java
@@ -1,0 +1,35 @@
+package com.electricip.loganalyzer.domain;
+
+/**
+ * IP 정보 Value Object
+ */
+public record IpInfo(
+    String ip,
+    String country,
+    String region,
+    String city,
+    String organization
+) {
+
+    public static IpInfo unknown(String ip) {
+        return new IpInfo(ip, "UNKNOWN", "UNKNOWN", "UNKNOWN", "UNKNOWN");
+    }
+    
+    /**
+     * 유효성 검사 포함
+     */
+    public static IpInfo of(String ip, String country, String region, 
+                           String city, String organization) {
+        if (ip == null || ip.isBlank()) {
+            throw new IllegalArgumentException("IP는 null이거나 비어있을 수 없습니다");
+        }
+        return new IpInfo(ip, country, region, city, organization);
+    }
+    
+    /**
+     * 유효한 IP 정보인지 확인
+     */
+    public boolean isValid() {
+        return country != null && !"UNKNOWN".equals(country);
+    }
+}


### PR DESCRIPTION
## Summary
도메인 모델(`AccessLog`, `IpInfo`, `AnalysisResult`) 구현 및 불변/검증 규칙 반영

## Context
- Issue: 
- Background:
  로그 파싱/통계 계산의 기반이 되는 순수 도메인 모델이 필요함.  
  외부 의존성 없이 도메인 규칙을 캡슐화하고, 불변성/기본값/검증을 통해 런타임 오류 가능성을 줄이는 목적.

## Changes
- Domain:
  - `AccessLog`(record) 추가: 로그 한 줄을 표현하는 불변 도메인 모델 및 도메인 메서드 포함
  - `IpInfo`(record) 추가: 정적 팩터리 메서드로 생성 규칙/검증 캡슐화 (`unknown()`, `of()`)
  - `AnalysisResult` 추가: 분석 결과 Aggregate(@Value + @Builder)로 결과 구조 표준화
  - 컬렉션/옵션 값은 기본값 정책 및 방어적 복사/빈 컬렉션 반환 원칙을 따르도록 설계
- Application:
- Infrastructure:
- API:
- Config / Build:

---

## Code Convention Checklist
- [x] 생성 로직은 정적 팩터리/빌더로 캡슐화 (`IpInfo`, `AnalysisResult`)
- [x] 도메인 객체 불변성 유지 (record / @Value)
- [x] 매개변수 유효성 검사 및 Fail-Fast 적용 (`IpInfo.of()` 등)
- [x] 컬렉션은 외부 변경 방지(방어적 복사/불변 래핑) 및 null 대신 빈 컬렉션 반환
- [ ] try-with-resources (해당 PR 범위 아님)
- [ ] 외부 시스템 연동 격리 (해당 PR 범위 아님)

---

## Behavior Change
- Before:
  - 로그/분석 결과 표현이 구조화되어 있지 않아 계층 간 데이터 계약이 느슨함
- After:
  - 도메인 모델을 기준으로 데이터 계약이 고정되고, 생성/검증/불변 규칙이 도메인 내부에 캡슐화됨

## Test
```bash
./gradlew build
# (테스트는 다음 PR에서 추가 예정이면 명시)
```

## Risk & Rollback
- Risk:
- Rollback: