### PR TITLE
Feature(infrastructure): 로그 파싱 및 외부 API 연동 인프라 구현

### DIFF
--- a/src/main/java/com/electricip/loganalyzer/config/CacheConfig.java
+++ b/src/main/java/com/electricip/loganalyzer/config/CacheConfig.java
@@ -1,0 +1,36 @@
+package com.electricip.loganalyzer.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 캐시 설정
+ * 
+ * Caffeine: Spring Boot 공식 권장
+ * - Window TinyLFU 알고리즘
+ * - 높은 적중률 (85%)
+ * - ipinfo API 비용 절감
+ */
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        var cacheManager = new CaffeineCacheManager();
+        
+        cacheManager.setCaffeine(Caffeine.newBuilder()
+                .maximumSize(10_000)
+                .expireAfterWrite(1, TimeUnit.HOURS)
+                .initialCapacity(100)
+                .recordStats());
+        
+        return cacheManager;
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/config/OpenApiConfig.java
+++ b/src/main/java/com/electricip/loganalyzer/config/OpenApiConfig.java
@@ -1,0 +1,33 @@
+package com.electricip.loganalyzer.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * OpenAPI/Swagger 설정
+ */
+@Configuration
+public class OpenApiConfig {
+    
+    /**
+     * OpenAPI 설정
+     */
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Log Analyzer API")
+                        .version("1.0.0")
+                        .description("""
+                                # Log Analyzer API
+                                
+                                ## 주요 기능
+                                - CSV 로그 파싱 (스트리밍)
+                                - 통계 분석
+                                - ipinfo API 연동
+                                - Caffeine 캐싱
+                                """));
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/config/WebConfig.java
+++ b/src/main/java/com/electricip/loganalyzer/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.electricip.loganalyzer.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Web 설정
+ */
+@Configuration
+public class WebConfig {
+    
+    /**
+     * RestTemplate Bean
+     */
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoClient.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoClient.java
@@ -1,0 +1,89 @@
+package com.electricip.loganalyzer.infrastructure.client;
+
+import com.electricip.loganalyzer.domain.IpInfo;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Objects;
+
+/**
+ * ipinfo.io API 클라이언트
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class IpInfoClient {
+    
+    // 의존 객체 주입
+    private final RestTemplate restTemplate;
+    
+    @Value("${ipinfo.base-url:https://ipinfo.io}")
+    private String baseUrl;
+    
+    @Value("${ipinfo.token:#{null}}")
+    private String token;
+    
+    /**
+     * IP 정보 조회 (캐싱 적용)
+     * 
+     * @param ip IP 주소
+     * @return IP 정보 (null 반환하지 않음)
+     * @throws NullPointerException ip가 null인 경우
+     */
+    @Cacheable(value = "ipInfoCache", key = "#ip", unless = "#result == null")
+    public IpInfo getIpInfo(String ip) {
+        Objects.requireNonNull(ip, "ip는 null일 수 없습니다");
+        
+        if (ip.isBlank()) {
+            log.warn("빈 IP 주소");
+            return IpInfo.unknown(ip);
+        }
+        
+        try {
+            var url = buildUrl(ip);
+            var response = restTemplate.getForObject(url, IpInfoResponse.class);
+            
+            if (response != null) {
+                log.debug("IP 정보 조회 성공: ip={}, country={}", ip, response.country);
+                
+                return IpInfo.of(
+                        response.ip,
+                        response.country,
+                        response.region,
+                        response.city,
+                        response.org
+                );
+            }
+        } catch (Exception e) {
+            log.warn("IP 정보 조회 실패: ip={}, error={}", ip, e.getMessage());
+        }
+        
+        return IpInfo.unknown(ip);
+    }
+    
+    /**
+     * API URL 구성
+     */
+    private String buildUrl(String ip) {
+        if (token != null && !token.isBlank()) {
+            return String.format("%s/%s?token=%s", baseUrl, ip, token);
+        }
+        return String.format("%s/%s/json", baseUrl, ip);
+    }
+    
+    /**
+     * ipinfo API 응답 DTO (Record)
+     */
+    private record IpInfoResponse(
+            @JsonProperty("ip") String ip,
+            @JsonProperty("country") String country,
+            @JsonProperty("region") String region,
+            @JsonProperty("city") String city,
+            @JsonProperty("org") String org
+    ) {}
+}

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/parser/CsvLogParser.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/parser/CsvLogParser.java
@@ -1,0 +1,170 @@
+package com.electricip.loganalyzer.infrastructure.parser;
+
+import com.electricip.loganalyzer.domain.AccessLog;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.io.input.BOMInputStream;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * CSV 로그 파서
+ */
+@Slf4j
+@Component
+public class CsvLogParser {
+    
+    private static final int MAX_ERROR_SAMPLES = 5;
+    private static final DateTimeFormatter FORMATTER = 
+            DateTimeFormatter.ofPattern("M/d/yyyy, h:mm:ss.SSS a", Locale.ENGLISH);
+    
+    @Value("${log-analysis.max-file-lines:200000}")
+    private int maxFileLines;
+    
+    /**
+     * CSV 파일 파싱
+     * 
+     * @param inputStream CSV 입력 스트림
+     * @return 파싱 결과
+     * @throws NullPointerException inputStream이 null인 경우
+     * @throws RuntimeException 파싱 실패 시
+     */
+    public ParseResult parse(InputStream inputStream) {
+        Objects.requireNonNull(inputStream, "inputStream은 null일 수 없습니다");
+        
+        var logs = new ArrayList<AccessLog>();
+        var errorSamples = new ArrayList<String>();
+        var errorCount = 0;
+        var lineNumber = 0;
+        
+        // try-with-resources
+        try (var reader = new BufferedReader(
+                new InputStreamReader(new BOMInputStream(inputStream), StandardCharsets.UTF_8))) {
+            
+            var csvFormat = CSVFormat.DEFAULT.builder()
+                    .setHeader()
+                    .setSkipHeaderRecord(true)
+                    .setIgnoreHeaderCase(true)
+                    .setTrim(true)
+                    .build();
+            
+            try (var csvParser = csvFormat.parse(reader)) {
+                for (CSVRecord record : csvParser) {
+                    lineNumber++;
+                    
+                    if (lineNumber > maxFileLines) {
+                        log.warn("최대 라인 수 도달: {}", maxFileLines);
+                        break;
+                    }
+                    
+                    try {
+                        var accessLog = parseRecord(record);
+                        logs.add(accessLog);
+                    } catch (Exception e) {
+                        errorCount++;
+                        if (errorSamples.size() < MAX_ERROR_SAMPLES) {
+                            errorSamples.add(String.format("Line %d: %s", 
+                                    lineNumber, e.getMessage()));
+                        }
+                    }
+                }
+            }
+            
+            log.info("파싱 완료: total={}, success={}, errors={}", 
+                    lineNumber, logs.size(), errorCount);
+            
+            return new ParseResult(logs, errorCount, errorSamples);
+            
+        } catch (Exception e) {
+            log.error("CSV 파싱 실패", e);
+            throw new RuntimeException("CSV 파일 파싱 실패: " + e.getMessage(), e);
+        }
+    }
+    
+    /**
+     * CSV 레코드를 AccessLog로 변환
+     */
+    private AccessLog parseRecord(CSVRecord record) {
+        return new AccessLog(
+                parseDateTime(record.get("TimeGenerated [UTC]")),
+                record.get("ClientIp"),
+                record.get("HttpMethod"),
+                record.get("RequestUri"),
+                record.get("UserAgent"),
+                parseInteger(record.get("HttpStatus")),
+                record.get("HttpVersion"),
+                parseLong(record.get("ReceivedBytes")),
+                parseLong(record.get("SentBytes")),
+                parseDouble(record.get("ClientResponseTime")),
+                record.get("SslProtocol"),
+                record.get("OriginalRequestUriWithArgs")
+        );
+    }
+    
+    private LocalDateTime parseDateTime(String value) {
+        if (value == null || value.isBlank()) return null;
+        try {
+            return LocalDateTime.parse(value.trim(), FORMATTER);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+    
+    private Integer parseInteger(String value) {
+        if (value == null || value.isBlank()) return null;
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+    
+    private Long parseLong(String value) {
+        if (value == null || value.isBlank()) return null;
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+    
+    private Double parseDouble(String value) {
+        if (value == null || value.isBlank()) return null;
+        try {
+            return Double.parseDouble(value.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+    
+    /**
+     * 파싱 결과 (Record)
+     */
+    public record ParseResult(
+            List<AccessLog> logs,
+            int errorCount,
+            List<String> errorSamples
+    ) {
+        /**
+         * 가변 컬렉션을 불변으로 변환
+         */
+        public ParseResult {
+            logs = List.copyOf(logs);
+            errorSamples = List.copyOf(errorSamples);
+        }
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/repository/AnalysisRepository.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/repository/AnalysisRepository.java
@@ -1,0 +1,97 @@
+package com.electricip.loganalyzer.infrastructure.repository;
+
+import com.electricip.loganalyzer.domain.AnalysisResult;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 분석 결과 저장소
+ * 
+ */
+@Repository
+public class AnalysisRepository {
+    
+    // Thread Safety
+    private final ConcurrentHashMap<String, AnalysisResult> storage = new ConcurrentHashMap<>();
+    
+    /**
+     * 저장
+     * 
+     * @param result 분석 결과
+     * @throws NullPointerException result가 null인 경우
+     */
+    public void save(AnalysisResult result) {
+        // 매개변수 유효성 검사
+        Objects.requireNonNull(result, "result는 null일 수 없습니다");
+        Objects.requireNonNull(result.getAnalysisId(), "analysisId는 null일 수 없습니다");
+        
+        storage.put(result.getAnalysisId(), result);
+    }
+    
+    /**
+     * ID로 조회
+     * 
+     * Optional 활용
+     * 
+     * @param analysisId 분석 ID
+     * @return 분석 결과 Optional
+     * @throws NullPointerException analysisId가 null인 경우
+     */
+    public Optional<AnalysisResult> findById(String analysisId) {
+        // 매개변수 유효성 검사
+        Objects.requireNonNull(analysisId, "analysisId는 null일 수 없습니다");
+        
+        return Optional.ofNullable(storage.get(analysisId));
+    }
+    
+    /**
+     * 전체 조회
+     * 
+     * 빈 컬렉션 반환 (null 반환하지 않음)
+     * 방어적 복사 (새로운 리스트 반환)
+     * 
+     * @return 분석 결과 리스트 (비어있을 수 있음)
+     */
+    public List<AnalysisResult> findAll() {
+        if (storage.isEmpty()) {
+            return Collections.emptyList();
+        }
+        
+        return new ArrayList<>(storage.values());
+    }
+    
+    /**
+     * 삭제
+     * 
+     * @param analysisId 분석 ID
+     * @return 삭제 성공 여부
+     * @throws NullPointerException analysisId가 null인 경우
+     */
+    public boolean deleteById(String analysisId) {
+        Objects.requireNonNull(analysisId, "analysisId는 null일 수 없습니다");
+        
+        return storage.remove(analysisId) != null;
+    }
+    
+    /**
+     * 개수 조회
+     * 
+     * @return 저장된 결과 개수
+     */
+    public int count() {
+        return storage.size();
+    }
+    
+    /**
+     * 전체 삭제 (테스트용)
+     */
+    public void deleteAll() {
+        storage.clear();
+    }
+}


### PR DESCRIPTION
## Summary
외부 연동 및 로그 처리에 필요한 인프라 레이어 구현

## Context
- Issue: 
- Background:
  로그 분석 서비스의 핵심 기능을 실제로 동작시키기 위해  
  외부 IP 정보 조회, 대용량 CSV 로그 파싱, 분석 결과 저장을 담당하는
  인프라 컴포넌트 구현이 필요

  도메인 레이어와 분리된 형태로,
  IO/외부 API/저장소 책임을 Infrastructure 레이어에 격리하는 것이 목적

## Changes
- Infrastructure:
  - `IpInfoClient` 구현
    - RestTemplate 기반 ipinfo.io API 클라이언트
    - Caffeine 캐시 적용(`@Cacheable`)으로 API 호출 비용 절감
    - 외부 API 실패 시 `IpInfo.unknown()`으로 Fallback 처리
    - 요청 파라미터 유효성 검사 적용
  - `CsvLogParser` 구현
    - Apache Commons CSV 기반 스트리밍 파싱
    - try-with-resources로 자원 안전 관리
    - 파싱 에러 수집 및 샘플 보관
    - 최대 200k 라인 제한으로 메모리 사용 보호
  - `AnalysisRepository` 구현
    - ConcurrentHashMap 기반 인메모리 저장소
    - Thread-safe 접근 보장
    - Optional 반환 및 빈 컬렉션 반환 정책 적용
- Config / Build:
  - `CacheConfig`: Caffeine CacheManager 설정
  - `WebConfig`: RestTemplate Bean 등록
  - `OpenApiConfig`: Swagger(OpenAPI) 문서 설정

---

## Code Convention Checklist
- [x] 외부 시스템 연동은 Infrastructure 레이어에 격리
- [x] 자원 사용 구간에 try-with-resources 적용
- [x] public 메서드 매개변수 유효성 검사 수행
- [x] 실패 케이스에 대한 Fallback 처리 적용
- [x] 동시 접근 가능 구조에 thread-safe 컬렉션 사용
- [x] Optional / 빈 컬렉션 반환 정책 준수

---

## Behavior Change
- Before:
  - 로그 파싱, IP 정보 조회, 결과 저장에 대한 실제 구현 부재
- After:
  - CSV 로그 업로드 → 스트리밍 파싱 → IP 정보 조회 → 분석 결과 저장까지
    전체 인프라 흐름이 동작 가능한 상태로 구성됨

## Test
```bash
./gradlew build
```
인프라 컴포넌트는 이후 단위/통합 테스트 PR에서 보강 예정

## Risk & Rollback

- Risk:
외부 API(ipinfo.io) 의존성으로 인한 응답 지연 또는 실패 가능성

- Rollback:
Infrastructure 레이어 추가 중심이므로,
문제 발생 시 해당 컴포넌트 사용 지점 제거 또는 비활성화로 대응 가능