### PR TITLE
feat(api): 로그 분석 REST API 및 전역 예외 처리 구현

### DIFF
--- a/src/main/java/com/electricip/loganalyzer/api/AnalysisController.java
+++ b/src/main/java/com/electricip/loganalyzer/api/AnalysisController.java
@@ -1,0 +1,100 @@
+package com.electricip.loganalyzer.api;
+
+import com.electricip.loganalyzer.application.AnalysisService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * 로그 분석 REST API
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/analysis")
+@RequiredArgsConstructor
+@Validated
+@Tag(name = "Log Analysis", description = "로그 분석 API")
+public class AnalysisController {
+    
+    private final AnalysisService analysisService;
+    
+    /**
+     * 로그 파일 분석
+     */
+    @PostMapping
+    @Operation(summary = "로그 파일 분석", description = "CSV 로그 파일을 업로드하여 분석합니다")
+    public ResponseEntity<AnalysisIdResponse> analyze(
+            @RequestParam("file") @NotNull(message = "파일은 필수입니다") MultipartFile file) {
+        
+        log.info("분석 요청: file={}", file.getOriginalFilename());
+        
+        var result = analysisService.analyze(file);
+        
+        return ResponseEntity.ok(new AnalysisIdResponse(
+                result.getAnalysisId(),
+                "분석이 완료되었습니다"
+        ));
+    }
+    
+    /**
+     * 분석 결과 조회
+     */
+    @GetMapping("/{analysisId}")
+    @Operation(summary = "분석 결과 조회", description = "분석 ID로 결과를 조회합니다")
+    public ResponseEntity<AnalysisResponse> getResult(@PathVariable String analysisId) {
+
+        Objects.requireNonNull(analysisId, "analysisId는 null일 수 없습니다");
+        
+        return analysisService.getById(analysisId)
+                .map(AnalysisResponse::from)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+    
+    /**
+     * 전체 결과 조회
+     */
+    @GetMapping
+    @Operation(summary = "전체 결과 조회", description = "모든 분석 결과를 조회합니다")
+    public ResponseEntity<List<AnalysisResponse>> getAllResults() {
+        
+        var results = analysisService.getAll().stream()
+                .map(AnalysisResponse::from)
+                .toList();
+        
+        return ResponseEntity.ok(results);
+    }
+    
+    /**
+     * 결과 삭제
+     */
+    @DeleteMapping("/{analysisId}")
+    @Operation(summary = "결과 삭제", description = "분석 결과를 삭제합니다")
+    public ResponseEntity<Void> deleteResult(@PathVariable String analysisId) {
+        
+        Objects.requireNonNull(analysisId, "analysisId는 null일 수 없습니다");
+        
+        var deleted = analysisService.delete(analysisId);
+        return deleted ? ResponseEntity.ok().build() : ResponseEntity.notFound().build();
+    }
+    
+    /**
+     * 분석 ID 응답 (Record)
+     */
+    public record AnalysisIdResponse(String analysisId, String message) {
+
+        public AnalysisIdResponse {
+            Objects.requireNonNull(analysisId, "analysisId는 null일 수 없습니다");
+            Objects.requireNonNull(message, "message는 null일 수 없습니다");
+        }
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/api/AnalysisResponse.java
+++ b/src/main/java/com/electricip/loganalyzer/api/AnalysisResponse.java
@@ -1,0 +1,159 @@
+package com.electricip.loganalyzer.api;
+
+import com.electricip.loganalyzer.domain.AnalysisResult;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * 분석 결과 응답 DTO
+ */
+@Builder
+public record AnalysisResponse(
+        String analysisId,
+        LocalDateTime completedAt,
+        Long processingTimeMs,
+        BasicStats basicStats,
+        TopStats topStats,
+        List<IpDetail> ipDetails,
+        ParseErrors parseErrors,
+        AdditionalStats additionalStats
+) {
+    /**
+     * 도메인 모델을 DTO로 변환
+     */
+    public static AnalysisResponse from(AnalysisResult result) {
+        Objects.requireNonNull(result, "result는 null일 수 없습니다");
+        
+        var stats = result.getStatistics();
+        
+        return AnalysisResponse.builder()
+                .analysisId(result.getAnalysisId())
+                .completedAt(result.getCompletedAt())
+                .processingTimeMs(result.getProcessingTimeMs())
+                .basicStats(new BasicStats(
+                        stats.getTotalRequests(),
+                        stats.getSuccessCount(),
+                        stats.getRedirectCount(),
+                        stats.getClientErrorCount(),
+                        stats.getServerErrorCount(),
+                        stats.successRate(),
+                        stats.redirectRate(),
+                        stats.clientErrorRate(),
+                        stats.serverErrorRate()))
+                .topStats(new TopStats(
+                        convertTopItems(stats.getTopPaths()),
+                        convertTopItemsForStatusCodes(stats.getTopStatusCodes()),
+                        convertTopItemsForIps(stats.getTopIps())))
+                .ipDetails(convertIpDetails(result.getIpDetails()))
+                .parseErrors(new ParseErrors(
+                        result.getParseErrors().errorCount(),
+                        result.getParseErrors().errorSamples()))
+                .additionalStats(new AdditionalStats(
+                        stats.getMethodStats(),
+                        stats.getAvgResponseTime(),
+                        stats.getAvgSentBytes(),
+                        stats.getTotalTraffic()))
+                .build();
+    }
+
+    private static List<PathStat> convertTopItems(List<AnalysisResult.TopItem> items) {
+        if (items.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return items.stream()
+                .map(t -> new PathStat(t.item(), t.count()))
+                .toList();
+    }
+    
+    private static List<StatusCodeStat> convertTopItemsForStatusCodes(List<AnalysisResult.TopItem> items) {
+        if (items.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return items.stream()
+                .map(t -> new StatusCodeStat(t.item(), t.count()))
+                .toList();
+    }
+    
+    private static List<IpStat> convertTopItemsForIps(List<AnalysisResult.TopItem> items) {
+        if (items.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return items.stream()
+                .map(t -> new IpStat(t.item(), t.count()))
+                .toList();
+    }
+
+    private static List<IpDetail> convertIpDetails(Map<String, com.electricip.loganalyzer.domain.IpInfo> ipInfoMap) {
+        if (ipInfoMap.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return ipInfoMap.entrySet().stream()
+                .map(e -> new IpDetail(
+                        e.getKey(),
+                        e.getValue().country(),
+                        e.getValue().region(),
+                        e.getValue().city(),
+                        e.getValue().organization()))
+                .toList();
+    }
+    
+    // 내부 Record들
+    
+    public record BasicStats(
+            long totalRequests,
+            long successCount,
+            long redirectCount,
+            long clientErrorCount,
+            long serverErrorCount,
+            double successRate,
+            double redirectRate,
+            double clientErrorRate,
+            double serverErrorRate) {}
+    
+    public record TopStats(
+            List<PathStat> topPaths,
+            List<StatusCodeStat> topStatusCodes,
+            List<IpStat> topIps) {
+
+        public TopStats {
+            topPaths = List.copyOf(topPaths);
+            topStatusCodes = List.copyOf(topStatusCodes);
+            topIps = List.copyOf(topIps);
+        }
+    }
+    
+    public record PathStat(String path, long count) {}
+    public record StatusCodeStat(String statusCode, long count) {}
+    public record IpStat(String ip, long count) {}
+    
+    public record IpDetail(
+            String ip,
+            String country,
+            String region,
+            String city,
+            String organization) {}
+    
+    public record ParseErrors(
+            int errorCount,
+            List<String> errorSamples) {
+        public ParseErrors {
+            errorSamples = List.copyOf(errorSamples);
+        }
+    }
+    
+    public record AdditionalStats(
+            Map<String, Long> methodStats,
+            double avgResponseTime,
+            double avgSentBytes,
+            long totalTraffic) {
+
+        public AdditionalStats {
+            methodStats = Map.copyOf(methodStats);
+        }
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/electricip/loganalyzer/api/GlobalExceptionHandler.java
@@ -1,0 +1,117 @@
+package com.electricip.loganalyzer.api;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+import java.time.LocalDateTime;
+
+/**
+ * 전역 예외 처리기
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    
+    /**
+     * IllegalArgumentException 처리
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgument(
+            IllegalArgumentException e, HttpServletRequest request) {
+        
+        log.error("잘못된 요청: {}", e.getMessage());
+        
+        return ResponseEntity
+                .badRequest()
+                .body(ErrorResponse.of(
+                        HttpStatus.BAD_REQUEST,
+                        "INVALID_REQUEST",
+                        e.getMessage(),
+                        request.getRequestURI()
+                ));
+    }
+    
+    /**
+     * NullPointerException 처리
+     */
+    @ExceptionHandler(NullPointerException.class)
+    public ResponseEntity<ErrorResponse> handleNullPointer(
+            NullPointerException e, HttpServletRequest request) {
+        
+        log.error("Null 참조: {}", e.getMessage());
+        
+        return ResponseEntity
+                .badRequest()
+                .body(ErrorResponse.of(
+                        HttpStatus.BAD_REQUEST,
+                        "NULL_REFERENCE",
+                        e.getMessage(),
+                        request.getRequestURI()
+                ));
+    }
+    
+    /**
+     * 파일 크기 초과
+     */
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceeded(
+            MaxUploadSizeExceededException e, HttpServletRequest request) {
+        
+        log.error("파일 크기 초과");
+        
+        return ResponseEntity
+                .status(HttpStatus.PAYLOAD_TOO_LARGE)
+                .body(ErrorResponse.of(
+                        HttpStatus.PAYLOAD_TOO_LARGE,
+                        "FILE_TOO_LARGE",
+                        "파일 크기 초과 (최대 50MB)",
+                        request.getRequestURI()
+                ));
+    }
+    
+    /**
+     * 일반 예외
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(
+            Exception e, HttpServletRequest request) {
+        
+        log.error("서버 오류: {}", e.getMessage(), e);
+        
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ErrorResponse.of(
+                        HttpStatus.INTERNAL_SERVER_ERROR,
+                        "INTERNAL_ERROR",
+                        "서버 오류가 발생했습니다",
+                        request.getRequestURI()
+                ));
+    }
+    
+    /**
+     * 에러 응답 (Record)
+     */
+    public record ErrorResponse(
+            LocalDateTime timestamp,
+            int status,
+            String errorCode,
+            String message,
+            String path
+    ) {
+        public static ErrorResponse of(HttpStatus httpStatus, String errorCode, 
+                                      String message, String path) {
+            return new ErrorResponse(
+                    LocalDateTime.now(),
+                    httpStatus.value(),
+                    errorCode,
+                    message,
+                    path
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
로그 분석 기능을 외부에 제공하기 위한 API 레이어 구현.

## Context
- Issue: 
- Background:
  Application 레이어에서 제공하는 로그 분석 유스케이스를
  HTTP API로 노출하기 위해 컨트롤러, 응답 DTO, 전역 예외 처리 구성이 필요함.

  API 레이어는 요청/응답 변환과 예외 매핑에 집중하고,
  비즈니스 로직은 하위 계층에 위임하는 구조를 유지함.

## Changes
- API:
  - `AnalysisController` 구현
    - `POST /api/analysis`: 로그 파일 업로드 및 분석 요청
    - `GET /api/analysis/{id}`: 분석 결과 단건 조회
    - `GET /api/analysis`: 전체 분석 결과 조회
    - `DELETE /api/analysis/{id}`: 분석 결과 삭제
    - Bean Validation 적용으로 요청 파라미터 검증
  - `AnalysisResponse` DTO 구현
    - 도메인 모델 → API 응답 DTO 변환 책임 분리
    - 정적 팩터리 메서드 `from()` 제공
    - Java Record 기반 불변 DTO 설계
    - 컬렉션 필드 방어적 복사 적용
  - `GlobalExceptionHandler` 구현
    - `IllegalArgumentException` 처리
    - `MaxUploadSizeExceededException` 처리
    - 일관된 `ErrorResponse` 반환 구조 적용
    - 정적 팩터리 메서드 패턴으로 ErrorResponse 생성 규칙 캡슐화

---

## Code Convention Checklist
- [x] API 레이어는 요청/응답 변환 책임만 가짐
- [x] 비즈니스 로직을 컨트롤러에 포함하지 않음
- [x] DTO는 불변(record)으로 설계
- [x] 도메인 → DTO 변환 로직을 명시적으로 분리
- [x] 예외를 HTTP 응답으로 일관되게 매핑
- [x] public API 입력에 대해 Bean Validation 적용

---

## Behavior Change
- Before:
  - 로그 분석 기능을 호출할 수 있는 외부 API 부재
- After:
  - 로그 분석 요청, 결과 조회/삭제를 REST API로 수행 가능
  - 실패 케이스에 대해 일관된 에러 응답 구조 제공

## Test
```bash
./gradlew build
```

## Risk & Rollback
- Risk:
대용량 파일 업로드 시 요청 처리 시간 증가 가능성

- Rollback:
API 레이어 추가 중심이므로,
문제 발생 시 해당 엔드포인트 비활성화 또는 롤백 가능