### PR TITLE
feat(domain): 빌더 필수 필드 누락 방지를 위한 @NonNull 적용

### DIFF
--- a/src/main/java/com/electricip/loganalyzer/api/AnalysisResponse.java
+++ b/src/main/java/com/electricip/loganalyzer/api/AnalysisResponse.java
@@ -2,6 +2,7 @@ package com.electricip.loganalyzer.api;
 
 import com.electricip.loganalyzer.domain.AnalysisResult;
 import lombok.Builder;
+import lombok.NonNull;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -14,23 +15,23 @@ import java.util.Objects;
  */
 @Builder
 public record AnalysisResponse(
-        String analysisId,
-        LocalDateTime completedAt,
+        @NonNull String analysisId,
+        @NonNull LocalDateTime completedAt,
         Long processingTimeMs,
-        BasicStats basicStats,
-        TopStats topStats,
-        List<IpDetail> ipDetails,
-        ParseErrors parseErrors,
-        AdditionalStats additionalStats
+        @NonNull BasicStats basicStats,
+        @NonNull TopStats topStats,
+        @NonNull List<IpDetail> ipDetails,
+        @NonNull ParseErrors parseErrors,
+        @NonNull AdditionalStats additionalStats
 ) {
     /**
      * 도메인 모델을 DTO로 변환
      */
     public static AnalysisResponse from(AnalysisResult result) {
         Objects.requireNonNull(result, "result는 null일 수 없습니다");
-        
+
         var stats = result.getStatistics();
-        
+
         return AnalysisResponse.builder()
                 .analysisId(result.getAnalysisId())
                 .completedAt(result.getCompletedAt())
@@ -69,7 +70,7 @@ public record AnalysisResponse(
                 .map(t -> new PathStat(t.item(), t.count()))
                 .toList();
     }
-    
+
     private static List<StatusCodeStat> convertTopItemsForStatusCodes(List<AnalysisResult.TopItem> items) {
         if (items.isEmpty()) {
             return Collections.emptyList();
@@ -78,7 +79,7 @@ public record AnalysisResponse(
                 .map(t -> new StatusCodeStat(t.item(), t.count()))
                 .toList();
     }
-    
+
     private static List<IpStat> convertTopItemsForIps(List<AnalysisResult.TopItem> items) {
         if (items.isEmpty()) {
             return Collections.emptyList();
@@ -101,9 +102,9 @@ public record AnalysisResponse(
                         e.getValue().organization()))
                 .toList();
     }
-    
+
     // 내부 Record들
-    
+
     public record BasicStats(
             long totalRequests,
             long successCount,
@@ -114,7 +115,7 @@ public record AnalysisResponse(
             double redirectRate,
             double clientErrorRate,
             double serverErrorRate) {}
-    
+
     public record TopStats(
             List<PathStat> topPaths,
             List<StatusCodeStat> topStatusCodes,
@@ -126,18 +127,18 @@ public record AnalysisResponse(
             topIps = List.copyOf(topIps);
         }
     }
-    
+
     public record PathStat(String path, long count) {}
     public record StatusCodeStat(String statusCode, long count) {}
     public record IpStat(String ip, long count) {}
-    
+
     public record IpDetail(
             String ip,
             String country,
             String region,
             String city,
             String organization) {}
-    
+
     public record ParseErrors(
             int errorCount,
             List<String> errorSamples) {
@@ -145,7 +146,7 @@ public record AnalysisResponse(
             errorSamples = List.copyOf(errorSamples);
         }
     }
-    
+
     public record AdditionalStats(
             Map<String, Long> methodStats,
             double avgResponseTime,

--- a/src/main/java/com/electricip/loganalyzer/domain/AnalysisResult.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/AnalysisResult.java
@@ -1,6 +1,7 @@
 package com.electricip.loganalyzer.domain;
 
 import lombok.Builder;
+import lombok.NonNull;
 import lombok.Value;
 
 import java.time.LocalDateTime;
@@ -14,16 +15,16 @@ import java.util.Map;
 @Value
 @Builder
 public class AnalysisResult {
-    String analysisId;
-    LocalDateTime completedAt;
+    @NonNull String analysisId;
+    @NonNull LocalDateTime completedAt;
     Long processingTimeMs;
-    
-    Statistics statistics;
+    @NonNull Statistics statistics;
+
     @Builder.Default
     Map<String, IpInfo> ipDetails = Collections.emptyMap();
     @Builder.Default
     ParseErrors parseErrors = ParseErrors.empty();
-    
+
     /**
      * 통계 Value Object
      */
@@ -35,60 +36,60 @@ public class AnalysisResult {
         long redirectCount;
         long clientErrorCount;
         long serverErrorCount;
-        
-        @Builder.Default
+
+        @NonNull @Builder.Default
         List<TopItem> topPaths = Collections.emptyList();
-        @Builder.Default
+        @NonNull @Builder.Default
         List<TopItem> topStatusCodes = Collections.emptyList();
-        @Builder.Default
+        @NonNull @Builder.Default
         List<TopItem> topIps = Collections.emptyList();
-        
-        @Builder.Default
+        @NonNull @Builder.Default
         Map<String, Long> methodStats = Collections.emptyMap();
+
         double avgResponseTime;
         double avgSentBytes;
         long totalTraffic;
-        
+
         /**
          * 도메인 로직: 비율 계산
          */
         public double successRate() {
             return calculateRate(successCount);
         }
-        
+
         public double redirectRate() {
             return calculateRate(redirectCount);
         }
-        
+
         public double clientErrorRate() {
             return calculateRate(clientErrorCount);
         }
-        
+
         public double serverErrorRate() {
             return calculateRate(serverErrorCount);
         }
-        
+
         private double calculateRate(long count) {
             if (totalRequests == 0) return 0.0;
             return Math.round((count * 100.0 / totalRequests) * 100.0) / 100.0;
         }
-        
+
         /**
          * 가변 컬렉션 반환 시 불변 뷰 제공
          */
         public List<TopItem> getTopPaths() {
             return Collections.unmodifiableList(topPaths);
         }
-        
+
         public List<TopItem> getTopIps() {
             return Collections.unmodifiableList(topIps);
         }
-        
+
         public Map<String, Long> getMethodStats() {
             return Collections.unmodifiableMap(methodStats);
         }
     }
-    
+
     /**
      * Top Item (Record)
      */
@@ -102,7 +103,7 @@ public class AnalysisResult {
             }
         }
     }
-    
+
     /**
      * 파싱 오류 (Record)
      */

--- a/src/test/java/com/electricip/loganalyzer/api/AnalysisResponseTest.java
+++ b/src/test/java/com/electricip/loganalyzer/api/AnalysisResponseTest.java
@@ -1,0 +1,106 @@
+package com.electricip.loganalyzer.api;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AnalysisResponseTest {
+
+    private static AnalysisResponse.BasicStats validBasicStats() {
+        return new AnalysisResponse.BasicStats(100, 80, 5, 10, 5, 80.0, 5.0, 10.0, 5.0);
+    }
+
+    private static AnalysisResponse.TopStats validTopStats() {
+        return new AnalysisResponse.TopStats(
+                Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+    }
+
+    private static AnalysisResponse.ParseErrors validParseErrors() {
+        return new AnalysisResponse.ParseErrors(0, Collections.emptyList());
+    }
+
+    private static AnalysisResponse.AdditionalStats validAdditionalStats() {
+        return new AnalysisResponse.AdditionalStats(Map.of(), 0.0, 0.0, 0);
+    }
+
+    @Test
+    @DisplayName("모든 필수 필드가 설정되면 정상 생성된다")
+    void shouldBuildWithAllRequiredFields() {
+        var response = AnalysisResponse.builder()
+                .analysisId("test-id")
+                .completedAt(LocalDateTime.of(2025, 1, 1, 0, 0))
+                .basicStats(validBasicStats())
+                .topStats(validTopStats())
+                .ipDetails(Collections.emptyList())
+                .parseErrors(validParseErrors())
+                .additionalStats(validAdditionalStats())
+                .build();
+
+        assertEquals("test-id", response.analysisId());
+        assertNotNull(response.completedAt());
+        assertNotNull(response.basicStats());
+    }
+
+    @Test
+    @DisplayName("analysisId 누락 시 NullPointerException 발생")
+    void shouldThrowWhenAnalysisIdIsNull() {
+        assertThrows(NullPointerException.class, () ->
+                AnalysisResponse.builder()
+                        .completedAt(LocalDateTime.now())
+                        .basicStats(validBasicStats())
+                        .topStats(validTopStats())
+                        .ipDetails(Collections.emptyList())
+                        .parseErrors(validParseErrors())
+                        .additionalStats(validAdditionalStats())
+                        .build());
+    }
+
+    @Test
+    @DisplayName("completedAt 누락 시 NullPointerException 발생")
+    void shouldThrowWhenCompletedAtIsNull() {
+        assertThrows(NullPointerException.class, () ->
+                AnalysisResponse.builder()
+                        .analysisId("test-id")
+                        .basicStats(validBasicStats())
+                        .topStats(validTopStats())
+                        .ipDetails(Collections.emptyList())
+                        .parseErrors(validParseErrors())
+                        .additionalStats(validAdditionalStats())
+                        .build());
+    }
+
+    @Test
+    @DisplayName("basicStats 누락 시 NullPointerException 발생")
+    void shouldThrowWhenBasicStatsIsNull() {
+        assertThrows(NullPointerException.class, () ->
+                AnalysisResponse.builder()
+                        .analysisId("test-id")
+                        .completedAt(LocalDateTime.now())
+                        .topStats(validTopStats())
+                        .ipDetails(Collections.emptyList())
+                        .parseErrors(validParseErrors())
+                        .additionalStats(validAdditionalStats())
+                        .build());
+    }
+
+    @Test
+    @DisplayName("선택 필드 processingTimeMs는 null 허용")
+    void shouldAllowNullProcessingTimeMs() {
+        var response = AnalysisResponse.builder()
+                .analysisId("test-id")
+                .completedAt(LocalDateTime.now())
+                .basicStats(validBasicStats())
+                .topStats(validTopStats())
+                .ipDetails(Collections.emptyList())
+                .parseErrors(validParseErrors())
+                .additionalStats(validAdditionalStats())
+                .build();
+
+        assertNull(response.processingTimeMs());
+    }
+}

--- a/src/test/java/com/electricip/loganalyzer/domain/AnalysisResultTest.java
+++ b/src/test/java/com/electricip/loganalyzer/domain/AnalysisResultTest.java
@@ -1,0 +1,174 @@
+package com.electricip.loganalyzer.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AnalysisResultTest {
+
+    private static AnalysisResult.Statistics validStatistics() {
+        return AnalysisResult.Statistics.builder()
+                .totalRequests(100)
+                .successCount(80)
+                .redirectCount(5)
+                .clientErrorCount(10)
+                .serverErrorCount(5)
+                .avgResponseTime(150.0)
+                .avgSentBytes(1024.0)
+                .totalTraffic(102400)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("AnalysisResult 빌더 검증")
+    class AnalysisResultBuilderTest {
+
+        @Test
+        @DisplayName("모든 필수 필드가 설정되면 정상 생성된다")
+        void shouldBuildWithAllRequiredFields() {
+            var result = AnalysisResult.builder()
+                    .analysisId("test-id")
+                    .completedAt(LocalDateTime.of(2025, 1, 1, 0, 0))
+                    .statistics(validStatistics())
+                    .build();
+
+            assertEquals("test-id", result.getAnalysisId());
+            assertNotNull(result.getCompletedAt());
+            assertNotNull(result.getStatistics());
+        }
+
+        @Test
+        @DisplayName("analysisId 누락 시 NullPointerException 발생")
+        void shouldThrowWhenAnalysisIdIsNull() {
+            var builder = AnalysisResult.builder()
+                    .completedAt(LocalDateTime.now())
+                    .statistics(validStatistics());
+
+            assertThrows(NullPointerException.class, builder::build);
+        }
+
+        @Test
+        @DisplayName("completedAt 누락 시 NullPointerException 발생")
+        void shouldThrowWhenCompletedAtIsNull() {
+            var builder = AnalysisResult.builder()
+                    .analysisId("test-id")
+                    .statistics(validStatistics());
+
+            assertThrows(NullPointerException.class, builder::build);
+        }
+
+        @Test
+        @DisplayName("statistics 누락 시 NullPointerException 발생")
+        void shouldThrowWhenStatisticsIsNull() {
+            var builder = AnalysisResult.builder()
+                    .analysisId("test-id")
+                    .completedAt(LocalDateTime.now());
+
+            assertThrows(NullPointerException.class, builder::build);
+        }
+
+        @Test
+        @DisplayName("선택 필드 processingTimeMs는 null 허용")
+        void shouldAllowNullProcessingTimeMs() {
+            var result = AnalysisResult.builder()
+                    .analysisId("test-id")
+                    .completedAt(LocalDateTime.now())
+                    .statistics(validStatistics())
+                    .build();
+
+            assertNull(result.getProcessingTimeMs());
+        }
+
+        @Test
+        @DisplayName("ipDetails 미설정 시 빈 맵이 기본값")
+        void shouldDefaultIpDetailsToEmptyMap() {
+            var result = AnalysisResult.builder()
+                    .analysisId("test-id")
+                    .completedAt(LocalDateTime.now())
+                    .statistics(validStatistics())
+                    .build();
+
+            assertNotNull(result.getIpDetails());
+            assertTrue(result.getIpDetails().isEmpty());
+        }
+
+        @Test
+        @DisplayName("parseErrors 미설정 시 empty가 기본값")
+        void shouldDefaultParseErrorsToEmpty() {
+            var result = AnalysisResult.builder()
+                    .analysisId("test-id")
+                    .completedAt(LocalDateTime.now())
+                    .statistics(validStatistics())
+                    .build();
+
+            assertNotNull(result.getParseErrors());
+            assertEquals(0, result.getParseErrors().errorCount());
+            assertTrue(result.getParseErrors().errorSamples().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("Statistics 빌더 검증")
+    class StatisticsBuilderTest {
+
+        @Test
+        @DisplayName("컬렉션 필드 미설정 시 빈 컬렉션이 기본값")
+        void shouldDefaultCollectionsToEmpty() {
+            var stats = AnalysisResult.Statistics.builder()
+                    .totalRequests(0)
+                    .successCount(0)
+                    .redirectCount(0)
+                    .clientErrorCount(0)
+                    .serverErrorCount(0)
+                    .avgResponseTime(0.0)
+                    .avgSentBytes(0.0)
+                    .totalTraffic(0)
+                    .build();
+
+            assertNotNull(stats.getTopPaths());
+            assertTrue(stats.getTopPaths().isEmpty());
+            assertNotNull(stats.getTopStatusCodes());
+            assertTrue(stats.getTopStatusCodes().isEmpty());
+            assertNotNull(stats.getTopIps());
+            assertTrue(stats.getTopIps().isEmpty());
+            assertNotNull(stats.getMethodStats());
+            assertTrue(stats.getMethodStats().isEmpty());
+        }
+
+        @Test
+        @DisplayName("topPaths에 null을 명시적으로 전달하면 NullPointerException 발생")
+        void shouldThrowWhenTopPathsIsExplicitlyNull() {
+            assertThrows(NullPointerException.class, () ->
+                    AnalysisResult.Statistics.builder()
+                            .totalRequests(0)
+                            .topPaths(null)
+                            .build());
+        }
+
+        @Test
+        @DisplayName("비율 계산이 정확하다")
+        void shouldCalculateRatesCorrectly() {
+            var stats = validStatistics();
+
+            assertEquals(80.0, stats.successRate());
+            assertEquals(5.0, stats.redirectRate());
+            assertEquals(10.0, stats.clientErrorRate());
+            assertEquals(5.0, stats.serverErrorRate());
+        }
+
+        @Test
+        @DisplayName("totalRequests가 0이면 비율은 0.0")
+        void shouldReturnZeroRateWhenNoRequests() {
+            var stats = AnalysisResult.Statistics.builder()
+                    .totalRequests(0)
+                    .build();
+
+            assertEquals(0.0, stats.successRate());
+            assertEquals(0.0, stats.clientErrorRate());
+        }
+    }
+}


### PR DESCRIPTION
 빌더 사용 시 필수 필드를 누락해도 컴파일 타임에 감지되지 않는 문제를 Lombok @NonNull + @Builder.Default로 해결하여 런타임 즉시 실패하도록 개선

 - AnalysisResult: analysisId, completedAt, statistics에 @NonNull 추가
 - Statistics: 컬렉션 필드에 @NonNull @Builder.Default 추가
 - AnalysisResponse: 필수 필드 7개에 @NonNull 추가
 - 단위 테스트 작성 (필수값 누락 NPE, 선택 필드 기본값 검증)

## Summary
<!-- 이 PR이 무엇을 변경하는지 한 줄 요약 -->

빌더 사용 시 필수 필드 누락을 조기에 감지하도록
@NonNull + @Builder.Default를 적용해 Fail-Fast 객체 생성 규칙을 강화

## Context
<!-- 왜 이 변경이 필요한지 / 배경 -->
- Issue: #1 
AnalysisResult 및 관련 객체를 빌더로 생성할 때
필수 필드를 누락해도 컴파일 타임에 감지되지 않는 문제가 존재함
  누락된 필드는 build() 이후 런타임 NPE로 이어질 수 있어 오류 원인 파악이 늦고 디버깅 비용이 큼
- Background: 
   1. Builder 패턴은 객체 생성 가독성과 확장성은 뛰어나지만,
  필수 필드를 컴파일 타임에 강제하기 어렵다는 구조적 한계가 있음
   2. 이를 보완하기 위한 방법으로 Custom Builder(build()에서 기본값 할당 + 필수값 검증)도 검토함
   3. Custom Builder를 사용할 경우 Lombok @Builder.Default는 제거하고
  기본값 적용과 유효성 검증을 build() 시점에 명시적으로 처리할 수 있음
   4. 다만 현재 도메인에서는 필수 필드 간 복잡한 제약이나 생성 순서 강제가 없고,
  누락 여부만 조기에 감지하면 충분하다고 판단함
   5. 이에 따라 설계 복잡도를 추가하는 Custom Builder 대신,
  Lombok @NonNull + @Builder.Default 조합을 통해
  객체 생성 시점에 즉시 실패(Fail-Fast)하도록 개선함
  6. 추후 필수 필드 간 제약 조건이 증가하거나
  생성 규칙이 복잡해질 경우, Custom Builder 또는 Step Builder 패턴 도입을 고려할 수 있음

## Changes
<!-- 변경 사항을 계층별로 간결하게 -->
- Domain:
  - `AnalysisResult`
    analysisId, completedAt, statistics에 @NonNull 추가
   선택 필드에 @Builder.Default 적용하여 기본값 보장
  - `Statistics`
   컬렉션 필드에 @NonNull + @Builder.Default 적용
   빌더 사용 시 null 컬렉션 유입 방지
- Application:
  - `AnalysisResponse`
     필수 필드 7개에 @NonNull 추가
     응답 DTO 생성 시 필수값 누락 즉시 실패하도록 보장

---

## Code Convention Checklist
> 본 PR은 프로젝트 코드 컨벤션을 기준으로 검토합니다.  
> 세부 기준은 `docs/CODE_CONVENTION.md`를 따릅니다.

### 1. 객체 생성 & 수명 관리
- [x] 생성 로직은 생성자 대신 **정적 팩터리 메서드** 또는 **빌더**로 캡슐화했다
- [x] 매개변수가 많은 객체는 **Builder 패턴**을 사용했다
- [ ] 의존 객체는 **생성자 주입**으로 전달했다
- [ ] 자원 사용 시 **try-with-resources**를 적용했다

### 2. 불변성 & 스레드 안정성
- [x] 도메인 객체는 **불변(record / @Value)** 으로 설계했다
- [ ] 내부 상태는 외부에서 수정할 수 없도록 보호했다
- [ ] 동시 접근 가능 구조에는 **thread-safe 컬렉션**을 사용했다

### 3. 메서드 계약
- [ ] public 메서드는 **매개변수 유효성 검사**를 수행한다
- [x] `null` 대신 **Optional 또는 빈 컬렉션**을 반환한다
- [ ] 컬렉션/배열은 **방어적 복사** 또는 불변 래핑을 적용했다
- [x] 실패 케이스는 **Fail-Fast**로 드러난다

### 4. 계층 분리
- [ ] Domain 레이어는 **외부 의존성(프레임워크/IO)** 이 없다
- [ ] 외부 시스템 연동은 Infrastructure 레이어에 격리했다
- [ ] Application 레이어는 오케스트레이션 책임만 가진다

### 5. 예외 & 로깅
- [ ] 예외 메시지는 **행동 가능한 정보**를 포함한다
- [ ] 성공/실패 로그 레벨을 구분했다
- [ ] 민감 정보는 로그에 남기지 않았다

---

## Behavior Change
<!-- 사용자/클라이언트 관점에서의 동작 변화 -->
- Before: 빌더 사용 시 필수 필드를 누락해도 객체 생성 가능
   누락된 필드는 런타임 중 NPE로 드러남
- After: 필수 필드 누락 시 build() 시점에 즉시 실패
  선택 필드는 항상 안전한 기본값을 가짐
  객체 생성 규칙이 명확해지고 디버깅 비용 감소

## Test
```bash
./gradlew test
./gradlew build
```

## Risk & Rollback
- Risk: 기존 코드에서 필수 필드를 암묵적으로 생략하던 부분이 있다면 빌드 또는 테스트 단계에서 실패할 수 있음
- Rollback: Lombok 어노테이션 변경 중심의 PR이므로 문제 발생 시 해당 커밋 단위로 롤백 가능