### PR TITLE
refactor(domain): Statistics를 Record로 전환하여 컬렉션 불변성 보장

### DIFF
--- a/src/main/java/com/electricip/loganalyzer/api/AnalysisResponse.java
+++ b/src/main/java/com/electricip/loganalyzer/api/AnalysisResponse.java
@@ -24,6 +24,11 @@ public record AnalysisResponse(
         @NonNull ParseErrors parseErrors,
         @NonNull AdditionalStats additionalStats
 ) {
+
+    public AnalysisResponse {
+        ipDetails = List.copyOf(ipDetails);
+    }
+
     /**
      * 도메인 모델을 DTO로 변환
      */
@@ -37,28 +42,28 @@ public record AnalysisResponse(
                 .completedAt(result.getCompletedAt())
                 .processingTimeMs(result.getProcessingTimeMs())
                 .basicStats(new BasicStats(
-                        stats.getTotalRequests(),
-                        stats.getSuccessCount(),
-                        stats.getRedirectCount(),
-                        stats.getClientErrorCount(),
-                        stats.getServerErrorCount(),
+                        stats.totalRequests(),
+                        stats.successCount(),
+                        stats.redirectCount(),
+                        stats.clientErrorCount(),
+                        stats.serverErrorCount(),
                         stats.successRate(),
                         stats.redirectRate(),
                         stats.clientErrorRate(),
                         stats.serverErrorRate()))
                 .topStats(new TopStats(
-                        convertTopItems(stats.getTopPaths()),
-                        convertTopItemsForStatusCodes(stats.getTopStatusCodes()),
-                        convertTopItemsForIps(stats.getTopIps())))
+                        convertTopItems(stats.topPaths()),
+                        convertTopItemsForStatusCodes(stats.topStatusCodes()),
+                        convertTopItemsForIps(stats.topIps())))
                 .ipDetails(convertIpDetails(result.getIpDetails()))
                 .parseErrors(new ParseErrors(
                         result.getParseErrors().errorCount(),
                         result.getParseErrors().errorSamples()))
                 .additionalStats(new AdditionalStats(
-                        stats.getMethodStats(),
-                        stats.getAvgResponseTime(),
-                        stats.getAvgSentBytes(),
-                        stats.getTotalTraffic()))
+                        stats.methodStats(),
+                        stats.avgResponseTime(),
+                        stats.avgSentBytes(),
+                        stats.totalTraffic()))
                 .build();
     }
 

--- a/src/main/java/com/electricip/loganalyzer/application/AnalysisService.java
+++ b/src/main/java/com/electricip/loganalyzer/application/AnalysisService.java
@@ -58,7 +58,7 @@ public class AnalysisService {
             var statistics = statisticsCalculator.calculate(logs);
             
             // 3. IP enrichment
-            var ipDetails = enrichIpInfo(statistics.getTopIps());
+            var ipDetails = enrichIpInfo(statistics.topIps());
             
             // 4. 결과 생성
             var result = AnalysisResult.builder()
@@ -78,7 +78,7 @@ public class AnalysisService {
             log.info("분석 완료: id={}, duration={}ms, total={}", 
                     result.getAnalysisId(), 
                     result.getProcessingTimeMs(),
-                    statistics.getTotalRequests());
+                    statistics.totalRequests());
             
             return result;
             

--- a/src/main/java/com/electricip/loganalyzer/domain/AnalysisResult.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/AnalysisResult.java
@@ -1,8 +1,6 @@
 package com.electricip.loganalyzer.domain;
 
-import lombok.Builder;
-import lombok.NonNull;
-import lombok.Value;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -20,35 +18,61 @@ public class AnalysisResult {
     Long processingTimeMs;
     @NonNull Statistics statistics;
 
-    @Builder.Default
-    Map<String, IpInfo> ipDetails = Collections.emptyMap();
-    @Builder.Default
-    ParseErrors parseErrors = ParseErrors.empty();
+    @Singular("ipDetail")
+    Map<String, IpInfo> ipDetails;
+
+    ParseErrors parseErrors;
+
+    /**
+     * 명시적 생성자
+     */
+    public AnalysisResult(
+            @NonNull String analysisId,
+            @NonNull LocalDateTime completedAt,
+            Long processingTimeMs,
+            @NonNull Statistics statistics,
+            Map<String, IpInfo> ipDetails,
+            ParseErrors parseErrors
+    ) {
+        this.analysisId = analysisId;
+        this.completedAt = completedAt;
+        this.processingTimeMs = processingTimeMs;
+        this.statistics = statistics;
+
+        this.ipDetails = (ipDetails == null) ? Map.of() : Map.copyOf(ipDetails);
+
+        // 기본값 보장
+        this.parseErrors = (parseErrors == null) ? ParseErrors.empty() : parseErrors;
+    }
+
 
     /**
      * 통계 Value Object
      */
-    @Value
     @Builder
-    public static class Statistics {
-        long totalRequests;
-        long successCount;
-        long redirectCount;
-        long clientErrorCount;
-        long serverErrorCount;
-
-        @NonNull @Builder.Default
-        List<TopItem> topPaths = Collections.emptyList();
-        @NonNull @Builder.Default
-        List<TopItem> topStatusCodes = Collections.emptyList();
-        @NonNull @Builder.Default
-        List<TopItem> topIps = Collections.emptyList();
-        @NonNull @Builder.Default
-        Map<String, Long> methodStats = Collections.emptyMap();
-
-        double avgResponseTime;
-        double avgSentBytes;
-        long totalTraffic;
+    public record Statistics(
+            long totalRequests,
+            long successCount,
+            long redirectCount,
+            long clientErrorCount,
+            long serverErrorCount,
+            List<TopItem> topPaths,
+            List<TopItem> topStatusCodes,
+            List<TopItem> topIps,
+            Map<String, Long> methodStats,
+            double avgResponseTime,
+            double avgSentBytes,
+            long totalTraffic
+    ) {
+        /**
+         * Compact Constructor: 방어적 복사
+         */
+        public Statistics {
+            topPaths = (topPaths != null) ? List.copyOf(topPaths) : List.of();
+            topStatusCodes = (topStatusCodes != null) ? List.copyOf(topStatusCodes) : List.of();
+            topIps = (topIps != null) ? List.copyOf(topIps) : List.of();
+            methodStats = (methodStats != null) ? Map.copyOf(methodStats) : Map.of();
+        }
 
         /**
          * 도메인 로직: 비율 계산
@@ -72,21 +96,6 @@ public class AnalysisResult {
         private double calculateRate(long count) {
             if (totalRequests == 0) return 0.0;
             return Math.round((count * 100.0 / totalRequests) * 100.0) / 100.0;
-        }
-
-        /**
-         * 가변 컬렉션 반환 시 불변 뷰 제공
-         */
-        public List<TopItem> getTopPaths() {
-            return Collections.unmodifiableList(topPaths);
-        }
-
-        public List<TopItem> getTopIps() {
-            return Collections.unmodifiableList(topIps);
-        }
-
-        public Map<String, Long> getMethodStats() {
-            return Collections.unmodifiableMap(methodStats);
         }
     }
 
@@ -119,9 +128,5 @@ public class AnalysisResult {
         public List<String> errorSamples() {
             return errorSamples; // 이미 불변
         }
-    }
-
-    public Map<String, IpInfo> getIpDetails() {
-        return Collections.unmodifiableMap(ipDetails);
     }
 }

--- a/src/test/java/com/electricip/loganalyzer/domain/AnalysisResultTest.java
+++ b/src/test/java/com/electricip/loganalyzer/domain/AnalysisResultTest.java
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -120,33 +123,16 @@ class AnalysisResultTest {
         void shouldDefaultCollectionsToEmpty() {
             var stats = AnalysisResult.Statistics.builder()
                     .totalRequests(0)
-                    .successCount(0)
-                    .redirectCount(0)
-                    .clientErrorCount(0)
-                    .serverErrorCount(0)
-                    .avgResponseTime(0.0)
-                    .avgSentBytes(0.0)
-                    .totalTraffic(0)
                     .build();
 
-            assertNotNull(stats.getTopPaths());
-            assertTrue(stats.getTopPaths().isEmpty());
-            assertNotNull(stats.getTopStatusCodes());
-            assertTrue(stats.getTopStatusCodes().isEmpty());
-            assertNotNull(stats.getTopIps());
-            assertTrue(stats.getTopIps().isEmpty());
-            assertNotNull(stats.getMethodStats());
-            assertTrue(stats.getMethodStats().isEmpty());
-        }
-
-        @Test
-        @DisplayName("topPaths에 null을 명시적으로 전달하면 NullPointerException 발생")
-        void shouldThrowWhenTopPathsIsExplicitlyNull() {
-            assertThrows(NullPointerException.class, () ->
-                    AnalysisResult.Statistics.builder()
-                            .totalRequests(0)
-                            .topPaths(null)
-                            .build());
+            assertNotNull(stats.topPaths());
+            assertTrue(stats.topPaths().isEmpty());
+            assertNotNull(stats.topStatusCodes());
+            assertTrue(stats.topStatusCodes().isEmpty());
+            assertNotNull(stats.topIps());
+            assertTrue(stats.topIps().isEmpty());
+            assertNotNull(stats.methodStats());
+            assertTrue(stats.methodStats().isEmpty());
         }
 
         @Test
@@ -169,6 +155,69 @@ class AnalysisResultTest {
 
             assertEquals(0.0, stats.successRate());
             assertEquals(0.0, stats.clientErrorRate());
+        }
+    }
+
+    @Nested
+    @DisplayName("Statistics 불변성 검증")
+    class StatisticsImmutabilityTest {
+
+        @Test
+        @DisplayName("빌더에 전달한 원본 리스트를 수정해도 Statistics 내부 상태는 변하지 않는다")
+        void shouldNotBeAffectedByOriginalListModification() {
+            var mutableList = new ArrayList<>(List.of(
+                    new AnalysisResult.TopItem("/api", 100)));
+
+            var stats = AnalysisResult.Statistics.builder()
+                    .totalRequests(100)
+                    .topPaths(mutableList)
+                    .build();
+
+            mutableList.clear();
+
+            assertEquals(1, stats.topPaths().size());
+            assertEquals("/api", stats.topPaths().get(0).item());
+        }
+
+        @Test
+        @DisplayName("빌더에 전달한 원본 맵을 수정해도 Statistics 내부 상태는 변하지 않는다")
+        void shouldNotBeAffectedByOriginalMapModification() {
+            var mutableMap = new HashMap<String, Long>();
+            mutableMap.put("GET", 50L);
+
+            var stats = AnalysisResult.Statistics.builder()
+                    .totalRequests(100)
+                    .methodStats(mutableMap)
+                    .build();
+
+            mutableMap.clear();
+
+            assertEquals(1, stats.methodStats().size());
+            assertEquals(50L, stats.methodStats().get("GET"));
+        }
+
+        @Test
+        @DisplayName("accessor로 반환된 리스트는 수정할 수 없다")
+        void shouldReturnUnmodifiableList() {
+            var stats = AnalysisResult.Statistics.builder()
+                    .totalRequests(100)
+                    .topPaths(List.of(new AnalysisResult.TopItem("/api", 100)))
+                    .build();
+
+            assertThrows(UnsupportedOperationException.class, () ->
+                    stats.topPaths().clear());
+        }
+
+        @Test
+        @DisplayName("accessor로 반환된 맵은 수정할 수 없다")
+        void shouldReturnUnmodifiableMap() {
+            var stats = AnalysisResult.Statistics.builder()
+                    .totalRequests(100)
+                    .methodStats(java.util.Map.of("GET", 50L))
+                    .build();
+
+            assertThrows(UnsupportedOperationException.class, () ->
+                    stats.methodStats().clear());
         }
     }
 }


### PR DESCRIPTION
 빌더로 생성 후 외부에서 원본 컬렉션을 수정하면 내부 상태가 변경되는 문제를 Compact Constructor의 방어적 복사(List.copyOf/Map.copyOf)로 해결

 - Statistics: @Value @Builder class → record @Builder 전환
 - Compact Constructor에서 null 기본값 처리 및 방어적 복사
 - getter 오버라이드 제거 (record accessor 사용)
 - 호출부 accessor 변경: getXxx() → xxx()
 - 불변성 단위 테스트 추가 (원본 수정 불변, accessor 반환값 수정 불가)

## Summary
<!-- 이 PR이 무엇을 변경하는지 한 줄 요약 -->

Statistics 도메인 객체를 record로 전환하고,
compact constructor의 방어적 복사를 통해 컬렉션 불변성을 보장.

## Context
<!-- 왜 이 변경이 필요한지 / 배경 -->
- Issue: #2 
Builder로 도메인 객체 생성 시, 외부에서 전달한 컬렉션(Map/List)의 레퍼런스가 그대로 저장되어
객체 생성 이후 외부 컬렉션을 수정하면 도메인 내부 상태까지 함께 변경되는 문제가 존재함
`Collections.unmodifiableXxx()` 기반의 반환만으로는 레퍼런스 공유 문제를 근본적으로 차단하지 못함

- Background:
  도메인 객체는 생성 이후 내부 상태가 변경되지 않아야 하며, 컬렉션 필드는 생성 시점에 불변성이 확정되어야 함
  이를 위해 Statistics를 record로 전환하고, `compact constructor`에서 `List.copyOf` / `Map.copyOf`를 사용해
     외부 컬렉션과의 레퍼런스 공유를 명시적으로 차단
  record accessor는 필드를 그대로 반환하므로, 생성 단계에서 불변화가 완료되면 별도의 getter 오버라이드는 불필요하다고 판단

## Changes
<!-- 변경 사항을 계층별로 간결하게 -->
- Domain:
  - `Statistics`
@Value @Builder 클래스 → record @Builder로 전환
compact constructor에서 컬렉션 필드에 대해 null 기본값 정규화, List.copyOf / Map.copyOf 기반 방어적 복사 적용
불변성 보장이 완료됨에 따라 컬렉션 getter 오버라이드 제거, record accessor 사용으로 단순화
호출부 접근 방식 변경 `getXxx()` → `xxx()`

---

## Code Convention Checklist
> 본 PR은 프로젝트 코드 컨벤션을 기준으로 검토합니다.  
> 세부 기준은 `docs/CODE_CONVENTION.md`를 따릅니다.

### 1. 객체 생성 & 수명 관리
- [ ] 생성 로직은 생성자 대신 **정적 팩터리 메서드** 또는 **빌더**로 캡슐화했다
- [x] 매개변수가 많은 객체는 **Builder 패턴**을 사용했다
- [ ] 의존 객체는 **생성자 주입**으로 전달했다
- [ ] 자원 사용 시 **try-with-resources**를 적용했다

### 2. 불변성 & 스레드 안정성
- [x] 도메인 객체는 **불변(record / @Value)** 으로 설계했다
- [x] 내부 상태는 외부에서 수정할 수 없도록 보호했다
- [ ] 동시 접근 가능 구조에는 **thread-safe 컬렉션**을 사용했다

### 3. 메서드 계약
- [ ] public 메서드는 **매개변수 유효성 검사**를 수행한다
- [x] `null` 대신 **Optional 또는 빈 컬렉션**을 반환한다
- [x] 컬렉션/배열은 **방어적 복사** 또는 불변 래핑을 적용했다
- [x] 실패 케이스는 **Fail-Fast**로 드러난다

### 4. 계층 분리
- [x] Domain 레이어는 **외부 의존성(프레임워크/IO)** 이 없다
- [ ] 외부 시스템 연동은 Infrastructure 레이어에 격리했다
- [ ] Application 레이어는 오케스트레이션 책임만 가진다

### 5. 예외 & 로깅
- [ ] 예외 메시지는 **행동 가능한 정보**를 포함한다
- [ ] 성공/실패 로그 레벨을 구분했다
- [ ] 민감 정보는 로그에 남기지 않았다

---

## Behavior Change
<!-- 사용자/클라이언트 관점에서의 동작 변화 -->
- Before: Builder로 생성된 Statistics에 전달된 컬렉션을 외부에서 수정하면 내부 상태도 함께 변경될 수 있음
- After: Statistics 생성 시 컬렉션이 불변 복사본으로 고정됨
   외부 컬렉션 수정 및 accessor 반환값 수정이 모두 차단됨

## Test
```bash
./gradlew test
./gradlew build
```
- 원본 컬렉션 수정 시 내부 상태가 변경되지 않음을 검증
- accessor로 반환된 컬렉션 수정 시 예외 발생을 검증

## Risk & Rollback
- Risk: 기존 호출부에서 getXxx() 형태의 accessor를 사용하던 코드가 있다면 컴파일 오류 발생 가능
- Rollback: Statistics를 기존 class 구조로 되돌리고 compact constructor 및 record 전환 커밋을 롤백하면 복구 가능