### PR TITLE
refactor(domain,api): compact constructor로 불변성·검증 강화

### DIFF
--- a/src/main/java/com/electricip/loganalyzer/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/electricip/loganalyzer/api/GlobalExceptionHandler.java
@@ -103,7 +103,17 @@ public class GlobalExceptionHandler {
             String message,
             String path
     ) {
-        public static ErrorResponse of(HttpStatus httpStatus, String errorCode, 
+        /**
+         * Compact Constructor: 필수 필드 검증 + message null 치환
+         */
+        public ErrorResponse {
+            java.util.Objects.requireNonNull(timestamp, "timestamp는 null일 수 없습니다");
+            java.util.Objects.requireNonNull(errorCode, "errorCode는 null일 수 없습니다");
+            java.util.Objects.requireNonNull(path, "path는 null일 수 없습니다");
+            message = (message != null) ? message : "알 수 없는 오류";
+        }
+
+        public static ErrorResponse of(HttpStatus httpStatus, String errorCode,
                                       String message, String path) {
             return new ErrorResponse(
                     LocalDateTime.now(),

--- a/src/main/java/com/electricip/loganalyzer/domain/IpInfo.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/IpInfo.java
@@ -11,21 +11,31 @@ public record IpInfo(
     String organization
 ) {
 
-    public static IpInfo unknown(String ip) {
-        return new IpInfo(ip, "UNKNOWN", "UNKNOWN", "UNKNOWN", "UNKNOWN");
-    }
-    
     /**
-     * 유효성 검사 포함
+     * Compact Constructor: ip 검증 + null/blank → "UNKNOWN" 치환
      */
-    public static IpInfo of(String ip, String country, String region, 
-                           String city, String organization) {
+    public IpInfo {
         if (ip == null || ip.isBlank()) {
             throw new IllegalArgumentException("IP는 null이거나 비어있을 수 없습니다");
         }
+        country = country != null && !country.isBlank() ? country : "UNKNOWN";
+        region = region != null && !region.isBlank() ? region : "UNKNOWN";
+        city = city != null && !city.isBlank() ? city : "UNKNOWN";
+        organization = organization != null && !organization.isBlank() ? organization : "UNKNOWN";
+    }
+
+    public static IpInfo unknown(String ip) {
+        return new IpInfo(ip, "UNKNOWN", "UNKNOWN", "UNKNOWN", "UNKNOWN");
+    }
+
+    /**
+     * 정적 팩터리 메서드 (compact constructor가 검증/치환 수행)
+     */
+    public static IpInfo of(String ip, String country, String region,
+                            String city, String organization) {
         return new IpInfo(ip, country, region, city, organization);
     }
-    
+
     /**
      * 유효한 IP 정보인지 확인
      */

--- a/src/test/java/com/electricip/loganalyzer/api/ErrorResponseTest.java
+++ b/src/test/java/com/electricip/loganalyzer/api/ErrorResponseTest.java
@@ -1,0 +1,89 @@
+package com.electricip.loganalyzer.api;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ErrorResponseTest {
+
+    @Nested
+    @DisplayName("Compact Constructor 검증")
+    class CompactConstructorTest {
+
+        @Test
+        @DisplayName("모든 필드가 정상이면 그대로 생성된다")
+        void shouldCreateWithValidFields() {
+            var response = new GlobalExceptionHandler.ErrorResponse(
+                    LocalDateTime.of(2025, 1, 1, 0, 0),
+                    400, "INVALID_REQUEST", "잘못된 요청", "/api/test");
+
+            assertEquals(400, response.status());
+            assertEquals("INVALID_REQUEST", response.errorCode());
+            assertEquals("잘못된 요청", response.message());
+            assertEquals("/api/test", response.path());
+        }
+
+        @Test
+        @DisplayName("message가 null이면 '알 수 없는 오류'로 치환된다")
+        void shouldReplaceNullMessageWithDefault() {
+            var response = new GlobalExceptionHandler.ErrorResponse(
+                    LocalDateTime.now(), 400, "CODE", null, "/api/test");
+
+            assertEquals("알 수 없는 오류", response.message());
+        }
+
+        @Test
+        @DisplayName("timestamp가 null이면 NullPointerException 발생")
+        void shouldThrowWhenTimestampIsNull() {
+            assertThrows(NullPointerException.class, () ->
+                    new GlobalExceptionHandler.ErrorResponse(
+                            null, 400, "CODE", "msg", "/api/test"));
+        }
+
+        @Test
+        @DisplayName("errorCode가 null이면 NullPointerException 발생")
+        void shouldThrowWhenErrorCodeIsNull() {
+            assertThrows(NullPointerException.class, () ->
+                    new GlobalExceptionHandler.ErrorResponse(
+                            LocalDateTime.now(), 400, null, "msg", "/api/test"));
+        }
+
+        @Test
+        @DisplayName("path가 null이면 NullPointerException 발생")
+        void shouldThrowWhenPathIsNull() {
+            assertThrows(NullPointerException.class, () ->
+                    new GlobalExceptionHandler.ErrorResponse(
+                            LocalDateTime.now(), 400, "CODE", "msg", null));
+        }
+    }
+
+    @Nested
+    @DisplayName("of() 팩터리 메서드 검증")
+    class OfFactoryMethodTest {
+
+        @Test
+        @DisplayName("정상 생성")
+        void shouldCreateViaOf() {
+            var response = GlobalExceptionHandler.ErrorResponse.of(
+                    HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "잘못된 요청", "/api/test");
+
+            assertEquals(400, response.status());
+            assertEquals("INVALID_REQUEST", response.errorCode());
+            assertEquals("잘못된 요청", response.message());
+        }
+
+        @Test
+        @DisplayName("of()에서 message가 null이면 기본 메시지로 치환된다")
+        void shouldReplaceNullMessageInOf() {
+            var response = GlobalExceptionHandler.ErrorResponse.of(
+                    HttpStatus.BAD_REQUEST, "CODE", null, "/api/test");
+
+            assertEquals("알 수 없는 오류", response.message());
+        }
+    }
+}

--- a/src/test/java/com/electricip/loganalyzer/domain/IpInfoTest.java
+++ b/src/test/java/com/electricip/loganalyzer/domain/IpInfoTest.java
@@ -1,0 +1,121 @@
+package com.electricip.loganalyzer.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IpInfoTest {
+
+    @Nested
+    @DisplayName("Compact Constructor 검증")
+    class CompactConstructorTest {
+
+        @Test
+        @DisplayName("모든 필드가 정상이면 그대로 생성된다")
+        void shouldCreateWithValidFields() {
+            var info = new IpInfo("1.2.3.4", "KR", "Seoul", "Gangnam", "ISP Corp");
+
+            assertEquals("1.2.3.4", info.ip());
+            assertEquals("KR", info.country());
+            assertEquals("Seoul", info.region());
+            assertEquals("Gangnam", info.city());
+            assertEquals("ISP Corp", info.organization());
+        }
+
+        @Test
+        @DisplayName("ip가 null이면 IllegalArgumentException 발생")
+        void shouldThrowWhenIpIsNull() {
+            assertThrows(IllegalArgumentException.class, () ->
+                    new IpInfo(null, "KR", "Seoul", "Gangnam", "ISP"));
+        }
+
+        @Test
+        @DisplayName("ip가 blank이면 IllegalArgumentException 발생")
+        void shouldThrowWhenIpIsBlank() {
+            assertThrows(IllegalArgumentException.class, () ->
+                    new IpInfo("  ", "KR", "Seoul", "Gangnam", "ISP"));
+        }
+
+        @Test
+        @DisplayName("country가 null이면 UNKNOWN으로 치환된다")
+        void shouldReplaceNullCountryWithUnknown() {
+            var info = new IpInfo("1.2.3.4", null, "Seoul", "Gangnam", "ISP");
+            assertEquals("UNKNOWN", info.country());
+        }
+
+        @Test
+        @DisplayName("region이 blank이면 UNKNOWN으로 치환된다")
+        void shouldReplaceBlankRegionWithUnknown() {
+            var info = new IpInfo("1.2.3.4", "KR", "  ", "Gangnam", "ISP");
+            assertEquals("UNKNOWN", info.region());
+        }
+
+        @Test
+        @DisplayName("모든 선택 필드가 null이면 전부 UNKNOWN으로 치환된다")
+        void shouldReplaceAllNullFieldsWithUnknown() {
+            var info = new IpInfo("1.2.3.4", null, null, null, null);
+
+            assertEquals("UNKNOWN", info.country());
+            assertEquals("UNKNOWN", info.region());
+            assertEquals("UNKNOWN", info.city());
+            assertEquals("UNKNOWN", info.organization());
+        }
+    }
+
+    @Nested
+    @DisplayName("팩터리 메서드 검증")
+    class FactoryMethodTest {
+
+        @Test
+        @DisplayName("of()는 compact constructor와 동일하게 동작한다")
+        void ofShouldDelegateToConstructor() {
+            var info = IpInfo.of("1.2.3.4", null, "Seoul", null, null);
+
+            assertEquals("1.2.3.4", info.ip());
+            assertEquals("UNKNOWN", info.country());
+            assertEquals("Seoul", info.region());
+            assertEquals("UNKNOWN", info.city());
+            assertEquals("UNKNOWN", info.organization());
+        }
+
+        @Test
+        @DisplayName("of()에서 ip가 null이면 IllegalArgumentException 발생")
+        void ofShouldThrowWhenIpIsNull() {
+            assertThrows(IllegalArgumentException.class, () ->
+                    IpInfo.of(null, "KR", "Seoul", "Gangnam", "ISP"));
+        }
+
+        @Test
+        @DisplayName("unknown()은 모든 필드가 UNKNOWN인 IpInfo를 반환한다")
+        void unknownShouldReturnAllUnknown() {
+            var info = IpInfo.unknown("1.2.3.4");
+
+            assertEquals("1.2.3.4", info.ip());
+            assertEquals("UNKNOWN", info.country());
+            assertEquals("UNKNOWN", info.region());
+            assertEquals("UNKNOWN", info.city());
+            assertEquals("UNKNOWN", info.organization());
+        }
+    }
+
+    @Nested
+    @DisplayName("isValid 검증")
+    class IsValidTest {
+
+        @Test
+        @DisplayName("country가 UNKNOWN이 아니면 유효하다")
+        void shouldBeValidWhenCountryIsKnown() {
+            var info = IpInfo.of("1.2.3.4", "KR", null, null, null);
+            assertTrue(info.isValid());
+        }
+
+        @Test
+        @DisplayName("country가 UNKNOWN이면 유효하지 않다")
+        void shouldBeInvalidWhenCountryIsUnknown() {
+            var info = IpInfo.unknown("1.2.3.4");
+            assertFalse(info.isValid());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
compact constructor를 도입해 객체 생성 시점에 검증과 정규화를 강제하고,
잘못된 상태의 도메인/API 객체가 생성되는 문제를 방지했습니다.

---

## Context

### Issue #3 
- record 객체가 public canonical constructor를 가지면서
  정적 팩터리 메서드(`of()`)를 우회해
  **검증되지 않은 상태의 객체 생성이 가능**했음
- ErrorResponse 생성 시 `e.getMessage()`가 null인 경우
  message가 null인 응답이 생성되거나,
  일부 필드 null로 인해 NPE 발생 가능성이 있었음

### Background
- 객체의 불변성과 유효성은 **반환 시점이 아니라 생성 시점에 확정**되어야 함
- 검증 로직이 팩터리 메서드에 분산되면
  생성 경로에 따라 규칙이 우회될 수 있어 유지보수성이 저하됨
- 이에 따라 검증 및 기본값 처리 로직을
  record의 compact constructor로 집중시키는 방향을 선택함

---

## Changes

### Domain
- `IpInfo`
  - compact constructor 추가
  - ip 유효성 검증 수행
  - null / blank 필드를 `"UNKNOWN"`으로 정규화
  - `of()` 팩터리를 constructor 위임으로 단순화하여 검증 우회 차단

### API
- `ErrorResponse`
  - compact constructor 추가
  - message가 null인 경우 기본 메시지로 치환
  - timestamp / errorCode / path null 방어로 NPE 방지

### Test
- `IpInfoTest`
  - compact constructor 검증
  - null/blank 치환
  - `of()`, `unknown()`, `isValid()` 동작 검증
- `ErrorResponseTest`
  - compact constructor null 처리 검증
  - `of()` 팩터리 메서드 동작 검증

---

## Code Convention Checklist

### 1. 객체 생성 & 수명 관리
- [x] 생성 규칙을 **생성자(compact constructor)** 에 캡슐화했다

### 2. 불변성 & 스레드 안정성
- [x] 도메인/응답 객체를 **불변(record)** 으로 설계했다
- [x] 내부 상태가 외부에서 변경되지 않도록 보호했다

### 3. 메서드 계약
- [x] public 생성 경로에서 **유효성 검증**을 수행한다
- [x] `null` 대신 **의미 있는 기본값**을 사용한다
- [x] 실패 케이스를 **Fail-Fast**로 드러낸다

### 4. 계층 분리
- [x] Domain 로직은 Domain 레이어에 집중했다
- [x] API 응답 정규화는 API 레이어에서 처리했다

---

## Behavior Change

### Before
- 팩터리 메서드를 우회해 검증되지 않은 객체 생성 가능
- ErrorResponse 생성 시 일부 필드 null로 인한 예외 가능성 존재

### After
- 모든 생성 경로에서 검증 및 기본값 처리가 강제됨
- 잘못된 상태의 객체 생성이 차단됨

---

## Test
```bash
./gradlew test
./gradlew build
```

## Risk & Rollback
- Risk: 기존 코드에서 null 입력을 허용하던 경우 동작이 변경될 수 있음
- Rollback: compact constructor 도입 커밋을 롤백하면 기존 생성 방식으로 복구 가능