### PR TITLE
test: 도메인 비즈니스 로직 및 불변성 테스트 강화

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.assertj:assertj-core:3.24.2")
     testImplementation("org.junit.jupiter:junit-jupiter")
 }
 

--- a/src/test/java/com/electricip/loganalyzer/domain/AccessLogTest.java
+++ b/src/test/java/com/electricip/loganalyzer/domain/AccessLogTest.java
@@ -1,0 +1,183 @@
+package com.electricip.loganalyzer.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AccessLogTest {
+
+    private AccessLog createLog(Integer httpStatus) {
+        return new AccessLog(
+                LocalDateTime.of(2025, 1, 1, 12, 0),
+                "1.2.3.4",
+                "GET",
+                "/api/test",
+                "Mozilla/5.0",
+                httpStatus,
+                "1.1",
+                100L,
+                200L,
+                0.1,
+                "TLSv1.3",
+                "/api/test?q=1"
+        );
+    }
+
+    @Nested
+    @DisplayName("isSuccessful() 검증")
+    class IsSuccessfulTest {
+
+        @ParameterizedTest(name = "상태 코드 {0}은 성공이다")
+        @ValueSource(ints = {200, 201, 204, 250, 299})
+        void shouldReturnTrue_whenStatusIs2xx(int status) {
+            var log = createLog(status);
+            assertThat(log.isSuccessful()).isTrue();
+        }
+
+        @ParameterizedTest(name = "상태 코드 {0}은 성공이 아니다")
+        @ValueSource(ints = {199, 300, 301, 400, 404, 500, 503})
+        void shouldReturnFalse_whenStatusIsNot2xx(int status) {
+            var log = createLog(status);
+            assertThat(log.isSuccessful()).isFalse();
+        }
+
+        @Test
+        @DisplayName("경계값: 200은 성공이다")
+        void shouldReturnTrue_whenStatusIs200() {
+            assertThat(createLog(200).isSuccessful()).isTrue();
+        }
+
+        @Test
+        @DisplayName("경계값: 299는 성공이다")
+        void shouldReturnTrue_whenStatusIs299() {
+            assertThat(createLog(299).isSuccessful()).isTrue();
+        }
+
+        @Test
+        @DisplayName("경계값: 199는 성공이 아니다")
+        void shouldReturnFalse_whenStatusIs199() {
+            assertThat(createLog(199).isSuccessful()).isFalse();
+        }
+
+        @Test
+        @DisplayName("경계값: 300은 성공이 아니다")
+        void shouldReturnFalse_whenStatusIs300() {
+            assertThat(createLog(300).isSuccessful()).isFalse();
+        }
+
+        @Test
+        @DisplayName("httpStatus가 null이면 성공이 아니다")
+        void shouldReturnFalse_whenStatusIsNull() {
+            assertThat(createLog(null).isSuccessful()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("statusCategory() 검증")
+    class StatusCategoryTest {
+
+        @ParameterizedTest(name = "상태 코드 {0}은 2xx 카테고리이다")
+        @ValueSource(ints = {200, 201, 250, 299})
+        void shouldReturn2xx_whenStatusIs200to299(int status) {
+            assertThat(createLog(status).statusCategory()).isEqualTo("2xx");
+        }
+
+        @ParameterizedTest(name = "상태 코드 {0}은 3xx 카테고리이다")
+        @ValueSource(ints = {300, 301, 302, 399})
+        void shouldReturn3xx_whenStatusIs300to399(int status) {
+            assertThat(createLog(status).statusCategory()).isEqualTo("3xx");
+        }
+
+        @ParameterizedTest(name = "상태 코드 {0}은 4xx 카테고리이다")
+        @ValueSource(ints = {400, 401, 403, 404, 499})
+        void shouldReturn4xx_whenStatusIs400to499(int status) {
+            assertThat(createLog(status).statusCategory()).isEqualTo("4xx");
+        }
+
+        @ParameterizedTest(name = "상태 코드 {0}은 5xx 카테고리이다")
+        @ValueSource(ints = {500, 502, 503, 599})
+        void shouldReturn5xx_whenStatusIs500to599(int status) {
+            assertThat(createLog(status).statusCategory()).isEqualTo("5xx");
+        }
+
+        @Test
+        @DisplayName("httpStatus가 null이면 Unknown")
+        void shouldReturnUnknown_whenStatusIsNull() {
+            assertThat(createLog(null).statusCategory()).isEqualTo("Unknown");
+        }
+
+        @ParameterizedTest(name = "상태 코드 {0}은 Unknown 카테고리이다")
+        @ValueSource(ints = {0, 100, 199, 600, 999})
+        void shouldReturnUnknown_whenStatusIsOutOfRange(int status) {
+            assertThat(createLog(status).statusCategory()).isEqualTo("Unknown");
+        }
+    }
+
+    @Nested
+    @DisplayName("null 필드 처리 검증")
+    class NullFieldTest {
+
+        @Test
+        @DisplayName("모든 필드가 null이어도 생성 가능하다")
+        void shouldAllowAllNullFields() {
+            var log = new AccessLog(null, null, null, null, null, null, null, null, null, null, null, null);
+
+            assertThat(log.timeGenerated()).isNull();
+            assertThat(log.clientIp()).isNull();
+            assertThat(log.httpMethod()).isNull();
+            assertThat(log.requestUri()).isNull();
+            assertThat(log.userAgent()).isNull();
+            assertThat(log.httpStatus()).isNull();
+            assertThat(log.httpVersion()).isNull();
+            assertThat(log.receivedBytes()).isNull();
+            assertThat(log.sentBytes()).isNull();
+            assertThat(log.clientResponseTime()).isNull();
+            assertThat(log.sslProtocol()).isNull();
+            assertThat(log.originalRequestUriWithArgs()).isNull();
+        }
+
+        @Test
+        @DisplayName("일부 필드만 null이어도 생성 가능하다")
+        void shouldAllowPartialNullFields() {
+            var log = new AccessLog(
+                    LocalDateTime.of(2025, 1, 1, 12, 0),
+                    "1.2.3.4",
+                    "GET",
+                    "/",
+                    null,
+                    200,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+
+            assertThat(log.clientIp()).isEqualTo("1.2.3.4");
+            assertThat(log.httpStatus()).isEqualTo(200);
+            assertThat(log.userAgent()).isNull();
+            assertThat(log.sslProtocol()).isNull();
+        }
+
+        @Test
+        @DisplayName("모든 필드가 null인 로그의 isSuccessful은 false")
+        void shouldReturnFalse_whenAllFieldsNull() {
+            var log = new AccessLog(null, null, null, null, null, null, null, null, null, null, null, null);
+            assertThat(log.isSuccessful()).isFalse();
+        }
+
+        @Test
+        @DisplayName("모든 필드가 null인 로그의 statusCategory는 Unknown")
+        void shouldReturnUnknown_whenAllFieldsNull() {
+            var log = new AccessLog(null, null, null, null, null, null, null, null, null, null, null, null);
+            assertThat(log.statusCategory()).isEqualTo("Unknown");
+        }
+    }
+}

--- a/src/test/java/com/electricip/loganalyzer/domain/AnalysisResultTest.java
+++ b/src/test/java/com/electricip/loganalyzer/domain/AnalysisResultTest.java
@@ -8,8 +8,10 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AnalysisResultTest {
 
@@ -39,9 +41,9 @@ class AnalysisResultTest {
                     .statistics(validStatistics())
                     .build();
 
-            assertEquals("test-id", result.getAnalysisId());
-            assertNotNull(result.getCompletedAt());
-            assertNotNull(result.getStatistics());
+            assertThat(result.getAnalysisId()).isEqualTo("test-id");
+            assertThat(result.getCompletedAt()).isNotNull();
+            assertThat(result.getStatistics()).isNotNull();
         }
 
         @Test
@@ -51,7 +53,8 @@ class AnalysisResultTest {
                     .completedAt(LocalDateTime.now())
                     .statistics(validStatistics());
 
-            assertThrows(NullPointerException.class, builder::build);
+            assertThatThrownBy(builder::build)
+                    .isInstanceOf(NullPointerException.class);
         }
 
         @Test
@@ -61,7 +64,8 @@ class AnalysisResultTest {
                     .analysisId("test-id")
                     .statistics(validStatistics());
 
-            assertThrows(NullPointerException.class, builder::build);
+            assertThatThrownBy(builder::build)
+                    .isInstanceOf(NullPointerException.class);
         }
 
         @Test
@@ -71,7 +75,8 @@ class AnalysisResultTest {
                     .analysisId("test-id")
                     .completedAt(LocalDateTime.now());
 
-            assertThrows(NullPointerException.class, builder::build);
+            assertThatThrownBy(builder::build)
+                    .isInstanceOf(NullPointerException.class);
         }
 
         @Test
@@ -83,7 +88,20 @@ class AnalysisResultTest {
                     .statistics(validStatistics())
                     .build();
 
-            assertNull(result.getProcessingTimeMs());
+            assertThat(result.getProcessingTimeMs()).isNull();
+        }
+
+        @Test
+        @DisplayName("processingTimeMs 설정 시 정상 반환")
+        void shouldReturnProcessingTimeMs() {
+            var result = AnalysisResult.builder()
+                    .analysisId("test-id")
+                    .completedAt(LocalDateTime.now())
+                    .statistics(validStatistics())
+                    .processingTimeMs(1500L)
+                    .build();
+
+            assertThat(result.getProcessingTimeMs()).isEqualTo(1500L);
         }
 
         @Test
@@ -95,8 +113,7 @@ class AnalysisResultTest {
                     .statistics(validStatistics())
                     .build();
 
-            assertNotNull(result.getIpDetails());
-            assertTrue(result.getIpDetails().isEmpty());
+            assertThat(result.getIpDetails()).isNotNull().isEmpty();
         }
 
         @Test
@@ -108,9 +125,63 @@ class AnalysisResultTest {
                     .statistics(validStatistics())
                     .build();
 
-            assertNotNull(result.getParseErrors());
-            assertEquals(0, result.getParseErrors().errorCount());
-            assertTrue(result.getParseErrors().errorSamples().isEmpty());
+            assertThat(result.getParseErrors()).isNotNull();
+            assertThat(result.getParseErrors().errorCount()).isZero();
+            assertThat(result.getParseErrors().errorSamples()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("ipDetails에 @Singular로 개별 항목 추가 가능")
+        void shouldAddIndividualIpDetail() {
+            var info = IpInfo.of("1.2.3.4", "KR", "Seoul", "Gangnam", "ISP");
+            var result = AnalysisResult.builder()
+                    .analysisId("test-id")
+                    .completedAt(LocalDateTime.now())
+                    .statistics(validStatistics())
+                    .ipDetail("1.2.3.4", info)
+                    .build();
+
+            assertThat(result.getIpDetails()).hasSize(1);
+            assertThat(result.getIpDetails().get("1.2.3.4")).isEqualTo(info);
+        }
+    }
+
+    @Nested
+    @DisplayName("AnalysisResult 불변성 검증")
+    class AnalysisResultImmutabilityTest {
+
+        @Test
+        @DisplayName("ipDetails 맵은 수정할 수 없다")
+        void shouldReturnUnmodifiableIpDetails() {
+            var result = AnalysisResult.builder()
+                    .analysisId("test-id")
+                    .completedAt(LocalDateTime.now())
+                    .statistics(validStatistics())
+                    .ipDetail("1.2.3.4", IpInfo.unknown("1.2.3.4"))
+                    .build();
+
+            assertThatThrownBy(() -> result.getIpDetails().clear())
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        @DisplayName("원본 맵 수정이 AnalysisResult에 영향을 주지 않는다")
+        void shouldDefensivelyCopyIpDetails() {
+            var mutableMap = new HashMap<String, IpInfo>();
+            mutableMap.put("1.2.3.4", IpInfo.unknown("1.2.3.4"));
+
+            var result = new AnalysisResult(
+                    "test-id",
+                    LocalDateTime.now(),
+                    null,
+                    validStatistics(),
+                    mutableMap,
+                    null
+            );
+
+            mutableMap.clear();
+
+            assertThat(result.getIpDetails()).hasSize(1);
         }
     }
 
@@ -125,14 +196,10 @@ class AnalysisResultTest {
                     .totalRequests(0)
                     .build();
 
-            assertNotNull(stats.topPaths());
-            assertTrue(stats.topPaths().isEmpty());
-            assertNotNull(stats.topStatusCodes());
-            assertTrue(stats.topStatusCodes().isEmpty());
-            assertNotNull(stats.topIps());
-            assertTrue(stats.topIps().isEmpty());
-            assertNotNull(stats.methodStats());
-            assertTrue(stats.methodStats().isEmpty());
+            assertThat(stats.topPaths()).isNotNull().isEmpty();
+            assertThat(stats.topStatusCodes()).isNotNull().isEmpty();
+            assertThat(stats.topIps()).isNotNull().isEmpty();
+            assertThat(stats.methodStats()).isNotNull().isEmpty();
         }
 
         @Test
@@ -140,10 +207,10 @@ class AnalysisResultTest {
         void shouldCalculateRatesCorrectly() {
             var stats = validStatistics();
 
-            assertEquals(80.0, stats.successRate());
-            assertEquals(5.0, stats.redirectRate());
-            assertEquals(10.0, stats.clientErrorRate());
-            assertEquals(5.0, stats.serverErrorRate());
+            assertThat(stats.successRate()).isEqualTo(80.0);
+            assertThat(stats.redirectRate()).isEqualTo(5.0);
+            assertThat(stats.clientErrorRate()).isEqualTo(10.0);
+            assertThat(stats.serverErrorRate()).isEqualTo(5.0);
         }
 
         @Test
@@ -153,8 +220,33 @@ class AnalysisResultTest {
                     .totalRequests(0)
                     .build();
 
-            assertEquals(0.0, stats.successRate());
-            assertEquals(0.0, stats.clientErrorRate());
+            assertThat(stats.successRate()).isEqualTo(0.0);
+            assertThat(stats.redirectRate()).isEqualTo(0.0);
+            assertThat(stats.clientErrorRate()).isEqualTo(0.0);
+            assertThat(stats.serverErrorRate()).isEqualTo(0.0);
+        }
+
+        @Test
+        @DisplayName("비율 계산 시 소수점 2자리까지 반올림된다")
+        void shouldRoundRateToTwoDecimalPlaces() {
+            var stats = AnalysisResult.Statistics.builder()
+                    .totalRequests(3)
+                    .successCount(1)
+                    .build();
+
+            // 1/3 * 100 = 33.333... → 33.33
+            assertThat(stats.successRate()).isEqualTo(33.33);
+        }
+
+        @Test
+        @DisplayName("모든 요청이 성공이면 100%")
+        void shouldReturn100PercentWhenAllSuccess() {
+            var stats = AnalysisResult.Statistics.builder()
+                    .totalRequests(50)
+                    .successCount(50)
+                    .build();
+
+            assertThat(stats.successRate()).isEqualTo(100.0);
         }
     }
 
@@ -175,8 +267,8 @@ class AnalysisResultTest {
 
             mutableList.clear();
 
-            assertEquals(1, stats.topPaths().size());
-            assertEquals("/api", stats.topPaths().get(0).item());
+            assertThat(stats.topPaths()).hasSize(1);
+            assertThat(stats.topPaths().get(0).item()).isEqualTo("/api");
         }
 
         @Test
@@ -192,8 +284,8 @@ class AnalysisResultTest {
 
             mutableMap.clear();
 
-            assertEquals(1, stats.methodStats().size());
-            assertEquals(50L, stats.methodStats().get("GET"));
+            assertThat(stats.methodStats()).hasSize(1);
+            assertThat(stats.methodStats().get("GET")).isEqualTo(50L);
         }
 
         @Test
@@ -204,8 +296,8 @@ class AnalysisResultTest {
                     .topPaths(List.of(new AnalysisResult.TopItem("/api", 100)))
                     .build();
 
-            assertThrows(UnsupportedOperationException.class, () ->
-                    stats.topPaths().clear());
+            assertThatThrownBy(() -> stats.topPaths().clear())
+                    .isInstanceOf(UnsupportedOperationException.class);
         }
 
         @Test
@@ -213,11 +305,134 @@ class AnalysisResultTest {
         void shouldReturnUnmodifiableMap() {
             var stats = AnalysisResult.Statistics.builder()
                     .totalRequests(100)
-                    .methodStats(java.util.Map.of("GET", 50L))
+                    .methodStats(Map.of("GET", 50L))
                     .build();
 
-            assertThrows(UnsupportedOperationException.class, () ->
-                    stats.methodStats().clear());
+            assertThatThrownBy(() -> stats.methodStats().clear())
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        @DisplayName("topStatusCodes 리스트도 수정할 수 없다")
+        void shouldReturnUnmodifiableStatusCodeList() {
+            var stats = AnalysisResult.Statistics.builder()
+                    .totalRequests(100)
+                    .topStatusCodes(List.of(new AnalysisResult.TopItem("200", 80)))
+                    .build();
+
+            assertThatThrownBy(() -> stats.topStatusCodes().clear())
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        @DisplayName("topIps 리스트도 수정할 수 없다")
+        void shouldReturnUnmodifiableIpList() {
+            var stats = AnalysisResult.Statistics.builder()
+                    .totalRequests(100)
+                    .topIps(List.of(new AnalysisResult.TopItem("1.2.3.4", 50)))
+                    .build();
+
+            assertThatThrownBy(() -> stats.topIps().clear())
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("TopItem 검증")
+    class TopItemTest {
+
+        @Test
+        @DisplayName("정상 값으로 생성된다")
+        void shouldCreateWithValidValues() {
+            var item = new AnalysisResult.TopItem("/api/users", 100);
+
+            assertThat(item.item()).isEqualTo("/api/users");
+            assertThat(item.count()).isEqualTo(100);
+        }
+
+        @Test
+        @DisplayName("count가 0이면 정상 생성된다")
+        void shouldAllowZeroCount() {
+            var item = new AnalysisResult.TopItem("/api", 0);
+
+            assertThat(item.count()).isZero();
+        }
+
+        @Test
+        @DisplayName("item이 null이면 IllegalArgumentException 발생")
+        void shouldThrowWhenItemIsNull() {
+            assertThatThrownBy(() -> new AnalysisResult.TopItem(null, 100))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("item");
+        }
+
+        @Test
+        @DisplayName("count가 음수이면 IllegalArgumentException 발생")
+        void shouldThrowWhenCountIsNegative() {
+            assertThatThrownBy(() -> new AnalysisResult.TopItem("/api", -1))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("count");
+        }
+
+        @Test
+        @DisplayName("빈 문자열 item은 허용된다")
+        void shouldAllowEmptyStringItem() {
+            var item = new AnalysisResult.TopItem("", 10);
+            assertThat(item.item()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("ParseErrors 검증")
+    class ParseErrorsTest {
+
+        @Test
+        @DisplayName("empty()는 errorCount 0, 빈 리스트를 반환한다")
+        void shouldCreateEmptyParseErrors() {
+            var errors = AnalysisResult.ParseErrors.empty();
+
+            assertThat(errors.errorCount()).isZero();
+            assertThat(errors.errorSamples()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("정상 값으로 생성된다")
+        void shouldCreateWithValues() {
+            var samples = List.of("error1", "error2");
+            var errors = new AnalysisResult.ParseErrors(2, samples);
+
+            assertThat(errors.errorCount()).isEqualTo(2);
+            assertThat(errors.errorSamples()).containsExactly("error1", "error2");
+        }
+
+        @Test
+        @DisplayName("errorSamples는 방어적 복사로 불변이다")
+        void shouldDefensivelyCopyErrorSamples() {
+            var mutableList = new ArrayList<>(List.of("error1"));
+            var errors = new AnalysisResult.ParseErrors(1, mutableList);
+
+            mutableList.clear();
+
+            assertThat(errors.errorSamples()).hasSize(1);
+            assertThat(errors.errorSamples().get(0)).isEqualTo("error1");
+        }
+
+        @Test
+        @DisplayName("errorSamples 반환 리스트는 수정할 수 없다")
+        void shouldReturnUnmodifiableErrorSamples() {
+            var errors = new AnalysisResult.ParseErrors(1, List.of("error1"));
+
+            assertThatThrownBy(() -> errors.errorSamples().clear())
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        @DisplayName("empty()의 errorSamples도 수정할 수 없다")
+        void shouldReturnUnmodifiableEmptyErrorSamples() {
+            var errors = AnalysisResult.ParseErrors.empty();
+
+            assertThatThrownBy(() -> errors.errorSamples().add("hack"))
+                    .isInstanceOf(UnsupportedOperationException.class);
         }
     }
 }

--- a/src/test/java/com/electricip/loganalyzer/domain/IpInfoTest.java
+++ b/src/test/java/com/electricip/loganalyzer/domain/IpInfoTest.java
@@ -4,7 +4,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class IpInfoTest {
 
@@ -17,39 +18,77 @@ class IpInfoTest {
         void shouldCreateWithValidFields() {
             var info = new IpInfo("1.2.3.4", "KR", "Seoul", "Gangnam", "ISP Corp");
 
-            assertEquals("1.2.3.4", info.ip());
-            assertEquals("KR", info.country());
-            assertEquals("Seoul", info.region());
-            assertEquals("Gangnam", info.city());
-            assertEquals("ISP Corp", info.organization());
+            assertThat(info.ip()).isEqualTo("1.2.3.4");
+            assertThat(info.country()).isEqualTo("KR");
+            assertThat(info.region()).isEqualTo("Seoul");
+            assertThat(info.city()).isEqualTo("Gangnam");
+            assertThat(info.organization()).isEqualTo("ISP Corp");
         }
 
         @Test
         @DisplayName("ip가 null이면 IllegalArgumentException 발생")
         void shouldThrowWhenIpIsNull() {
-            assertThrows(IllegalArgumentException.class, () ->
-                    new IpInfo(null, "KR", "Seoul", "Gangnam", "ISP"));
+            assertThatThrownBy(() -> new IpInfo(null, "KR", "Seoul", "Gangnam", "ISP"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("IP");
         }
 
         @Test
         @DisplayName("ip가 blank이면 IllegalArgumentException 발생")
         void shouldThrowWhenIpIsBlank() {
-            assertThrows(IllegalArgumentException.class, () ->
-                    new IpInfo("  ", "KR", "Seoul", "Gangnam", "ISP"));
+            assertThatThrownBy(() -> new IpInfo("  ", "KR", "Seoul", "Gangnam", "ISP"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("IP");
+        }
+
+        @Test
+        @DisplayName("ip가 빈 문자열이면 IllegalArgumentException 발생")
+        void shouldThrowWhenIpIsEmpty() {
+            assertThatThrownBy(() -> new IpInfo("", "KR", "Seoul", "Gangnam", "ISP"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("IP");
         }
 
         @Test
         @DisplayName("country가 null이면 UNKNOWN으로 치환된다")
         void shouldReplaceNullCountryWithUnknown() {
             var info = new IpInfo("1.2.3.4", null, "Seoul", "Gangnam", "ISP");
-            assertEquals("UNKNOWN", info.country());
+            assertThat(info.country()).isEqualTo("UNKNOWN");
         }
 
         @Test
         @DisplayName("region이 blank이면 UNKNOWN으로 치환된다")
         void shouldReplaceBlankRegionWithUnknown() {
             var info = new IpInfo("1.2.3.4", "KR", "  ", "Gangnam", "ISP");
-            assertEquals("UNKNOWN", info.region());
+            assertThat(info.region()).isEqualTo("UNKNOWN");
+        }
+
+        @Test
+        @DisplayName("city가 null이면 UNKNOWN으로 치환된다")
+        void shouldReplaceNullCityWithUnknown() {
+            var info = new IpInfo("1.2.3.4", "KR", "Seoul", null, "ISP");
+            assertThat(info.city()).isEqualTo("UNKNOWN");
+        }
+
+        @Test
+        @DisplayName("city가 blank이면 UNKNOWN으로 치환된다")
+        void shouldReplaceBlankCityWithUnknown() {
+            var info = new IpInfo("1.2.3.4", "KR", "Seoul", "  ", "ISP");
+            assertThat(info.city()).isEqualTo("UNKNOWN");
+        }
+
+        @Test
+        @DisplayName("organization이 null이면 UNKNOWN으로 치환된다")
+        void shouldReplaceNullOrganizationWithUnknown() {
+            var info = new IpInfo("1.2.3.4", "KR", "Seoul", "Gangnam", null);
+            assertThat(info.organization()).isEqualTo("UNKNOWN");
+        }
+
+        @Test
+        @DisplayName("organization이 blank이면 UNKNOWN으로 치환된다")
+        void shouldReplaceBlankOrganizationWithUnknown() {
+            var info = new IpInfo("1.2.3.4", "KR", "Seoul", "Gangnam", "  ");
+            assertThat(info.organization()).isEqualTo("UNKNOWN");
         }
 
         @Test
@@ -57,10 +96,21 @@ class IpInfoTest {
         void shouldReplaceAllNullFieldsWithUnknown() {
             var info = new IpInfo("1.2.3.4", null, null, null, null);
 
-            assertEquals("UNKNOWN", info.country());
-            assertEquals("UNKNOWN", info.region());
-            assertEquals("UNKNOWN", info.city());
-            assertEquals("UNKNOWN", info.organization());
+            assertThat(info.country()).isEqualTo("UNKNOWN");
+            assertThat(info.region()).isEqualTo("UNKNOWN");
+            assertThat(info.city()).isEqualTo("UNKNOWN");
+            assertThat(info.organization()).isEqualTo("UNKNOWN");
+        }
+
+        @Test
+        @DisplayName("모든 선택 필드가 blank이면 전부 UNKNOWN으로 치환된다")
+        void shouldReplaceAllBlankFieldsWithUnknown() {
+            var info = new IpInfo("1.2.3.4", "", " ", "\t", "\n");
+
+            assertThat(info.country()).isEqualTo("UNKNOWN");
+            assertThat(info.region()).isEqualTo("UNKNOWN");
+            assertThat(info.city()).isEqualTo("UNKNOWN");
+            assertThat(info.organization()).isEqualTo("UNKNOWN");
         }
     }
 
@@ -73,18 +123,19 @@ class IpInfoTest {
         void ofShouldDelegateToConstructor() {
             var info = IpInfo.of("1.2.3.4", null, "Seoul", null, null);
 
-            assertEquals("1.2.3.4", info.ip());
-            assertEquals("UNKNOWN", info.country());
-            assertEquals("Seoul", info.region());
-            assertEquals("UNKNOWN", info.city());
-            assertEquals("UNKNOWN", info.organization());
+            assertThat(info.ip()).isEqualTo("1.2.3.4");
+            assertThat(info.country()).isEqualTo("UNKNOWN");
+            assertThat(info.region()).isEqualTo("Seoul");
+            assertThat(info.city()).isEqualTo("UNKNOWN");
+            assertThat(info.organization()).isEqualTo("UNKNOWN");
         }
 
         @Test
         @DisplayName("of()에서 ip가 null이면 IllegalArgumentException 발생")
         void ofShouldThrowWhenIpIsNull() {
-            assertThrows(IllegalArgumentException.class, () ->
-                    IpInfo.of(null, "KR", "Seoul", "Gangnam", "ISP"));
+            assertThatThrownBy(() -> IpInfo.of(null, "KR", "Seoul", "Gangnam", "ISP"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("IP");
         }
 
         @Test
@@ -92,30 +143,45 @@ class IpInfoTest {
         void unknownShouldReturnAllUnknown() {
             var info = IpInfo.unknown("1.2.3.4");
 
-            assertEquals("1.2.3.4", info.ip());
-            assertEquals("UNKNOWN", info.country());
-            assertEquals("UNKNOWN", info.region());
-            assertEquals("UNKNOWN", info.city());
-            assertEquals("UNKNOWN", info.organization());
+            assertThat(info.ip()).isEqualTo("1.2.3.4");
+            assertThat(info.country()).isEqualTo("UNKNOWN");
+            assertThat(info.region()).isEqualTo("UNKNOWN");
+            assertThat(info.city()).isEqualTo("UNKNOWN");
+            assertThat(info.organization()).isEqualTo("UNKNOWN");
+        }
+
+        @Test
+        @DisplayName("unknown()에서 ip가 null이면 IllegalArgumentException 발생")
+        void unknownShouldThrowWhenIpIsNull() {
+            assertThatThrownBy(() -> IpInfo.unknown(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("IP");
         }
     }
 
     @Nested
-    @DisplayName("isValid 검증")
+    @DisplayName("isValid() 검증")
     class IsValidTest {
 
         @Test
         @DisplayName("country가 UNKNOWN이 아니면 유효하다")
         void shouldBeValidWhenCountryIsKnown() {
             var info = IpInfo.of("1.2.3.4", "KR", null, null, null);
-            assertTrue(info.isValid());
+            assertThat(info.isValid()).isTrue();
         }
 
         @Test
         @DisplayName("country가 UNKNOWN이면 유효하지 않다")
         void shouldBeInvalidWhenCountryIsUnknown() {
             var info = IpInfo.unknown("1.2.3.4");
-            assertFalse(info.isValid());
+            assertThat(info.isValid()).isFalse();
+        }
+
+        @Test
+        @DisplayName("country가 null로 전달되어 UNKNOWN 치환된 경우 유효하지 않다")
+        void shouldBeInvalidWhenCountryWasNull() {
+            var info = new IpInfo("1.2.3.4", null, "Seoul", "Gangnam", "ISP");
+            assertThat(info.isValid()).isFalse();
         }
     }
 }


### PR DESCRIPTION
## Summary
<!-- 이 PR이 무엇을 변경하는지 한 줄 요약 -->
도메인 핵심 비즈니스 로직과 불변성 규칙을 검증하는 테스트를 추가·확장하고 AssertJ 기반으로 테스트 표현력을 개선

## Context
<!-- 왜 이 변경이 필요한지 / 배경 -->
- Issue: #4 
도메인 로직(AccessLog, IpInfo, AnalysisResult)의 경계값, null 입력, 불변성 규칙에 대한 테스트 커버리지가 충분하지 않았음
일부 테스트는 JUnit 기본 assertion을 사용해 가독성과 실패 원인 파악이 어려웠음
- Background:
도메인 규칙은 구현 코드보다 테스트로 먼저 고정되는 것이 중요하다고 판단
특히 상태 코드 분류, 성공 여부 판단, 불변 컬렉션 유지 등은 경계값·예외 케이스에서의 동작이 명확히 보장되어야 함
테스트 범위를 정상 케이스 중심에서 경계값 / 범위 외 입력 / null 조합 / 불변성 검증까지 확장하고, AssertJ로 assertion 스타일을 통일함

## Changes
<!-- 변경 사항을 계층별로 간결하게 -->
- Domain:
  - `AccessLogTest`
  isSuccessful() : 경계값(199 / 200 / 299 / 300) 및 null 파라미터 검증
  statusCategory() : 2xx~5xx 전체 범위 + Unknown, 범위 외 값(0, 100, 600, 999) 검증
  전체 null / 부분 null 필드 조합에서 비즈니스 로직 동작 검증
  - `IpInfoTest`
  Unit assertion → AssertJ 전환
  빈 문자열 IP, blank 필드(city / organization), 전체 blank 입력 테스트 추가
  unknown(null) 예외 검증
  country == null일 때 isValid()가 false를 반환하는지 검증
  - `AnalysisResultTest`
  AssertJ 전환
  TopItem 검증 강화 null item, 음수 count, 경계값 count = 0
  AnalysisResult ipDetails 방어적 복사 및 불변성 검증
  ParseErrors empty() 동작, 방어적 복사, 불변성 검증

---

## Code Convention Checklist
> 본 PR은 프로젝트 코드 컨벤션을 기준으로 검토합니다.  
> 세부 기준은 `docs/CODE_CONVENTION.md`를 따릅니다.

### 1. 객체 생성 & 수명 관리
- [x] 도메인 객체 생성 규칙을 테스트로 검증했다

### 2. 불변성 & 스레드 안정성
- [x] 도메인 객체의 불변성을 테스트로 보장했다
- [x]  컬렉션 방어적 복사 및 수정 불가 상태를 검증했다

### 3. 메서드 계약
- [x]  경계값 및 범위 외 입력에 대한 동작을 명시적으로 검증했다
- [x]  null 입력에 대한 Fail-Fast 또는 안전한 처리 방식을 테스트로 고정했다

### 4. 계층 분리
- [x] Domain 레이어 로직을 외부 의존성 없이 검증했다

### 5. 예외 & 로깅
- [ ] 예외 메시지는 **행동 가능한 정보**를 포함한다
- [ ] 성공/실패 로그 레벨을 구분했다
- [ ] 민감 정보는 로그에 남기지 않았다

---

## Behavior Change
<!-- 사용자/클라이언트 관점에서의 동작 변화 -->
- Before: 일부 도메인 로직이 정상 입력 중심으로만 검증됨
  경계값, null 입력, 불변성 규칙이 테스트로 명확히 드러나지 않음
- After: 도메인 핵심 규칙이 경계값·예외 케이스까지 테스트로 고정됨
   테스트 실패 시 원인 파악이 쉬운 AssertJ 기반 assertion으로 개선됨

## Test
```bash
./gradlew test
./gradlew build
```

## Risk & Rollback 
- Risk: 테스트 강화로 인해 기존 구현의 숨겨진 버그가 드러날 수 있음
- Rollback: 테스트 코드 변경이므로, 문제 발생 시 해당 테스트 커밋만 롤백 가능