### PR TITLE
refactor: CSV 파서 헤더 검증 및 파싱 오류 구조화

### DIFF
--- a/src/main/java/com/electricip/loganalyzer/api/AnalysisResponse.java
+++ b/src/main/java/com/electricip/loganalyzer/api/AnalysisResponse.java
@@ -1,6 +1,8 @@
 package com.electricip.loganalyzer.api;
 
 import com.electricip.loganalyzer.domain.AnalysisResult;
+import com.electricip.loganalyzer.domain.ParseError;
+import com.electricip.loganalyzer.domain.ParseStatistics;
 import lombok.Builder;
 import lombok.NonNull;
 
@@ -21,7 +23,7 @@ public record AnalysisResponse(
         @NonNull BasicStats basicStats,
         @NonNull TopStats topStats,
         @NonNull List<IpDetail> ipDetails,
-        @NonNull ParseErrors parseErrors,
+        @NonNull ParseStatisticsDto parseStatistics,
         @NonNull AdditionalStats additionalStats
 ) {
 
@@ -56,15 +58,30 @@ public record AnalysisResponse(
                         convertTopItemsForStatusCodes(stats.topStatusCodes()),
                         convertTopItemsForIps(stats.topIps())))
                 .ipDetails(convertIpDetails(result.getIpDetails()))
-                .parseErrors(new ParseErrors(
-                        result.getParseErrors().errorCount(),
-                        result.getParseErrors().errorSamples()))
+                .parseStatistics(convertParseStatistics(result.getParseStatistics()))
                 .additionalStats(new AdditionalStats(
                         stats.methodStats(),
                         stats.avgResponseTime(),
                         stats.avgSentBytes(),
                         stats.totalTraffic()))
                 .build();
+    }
+
+    private static ParseStatisticsDto convertParseStatistics(ParseStatistics ps) {
+        var errorDtos = ps.errorSamples().stream()
+                .map(e -> new ParseErrorDto(
+                        e.lineNumber(),
+                        e.errorMessage(),
+                        e.errorType().name(),
+                        e.occurredAt()))
+                .toList();
+
+        return new ParseStatisticsDto(
+                ps.totalLines(),
+                ps.successCount(),
+                ps.errorCount(),
+                ps.errorsByType(),
+                errorDtos);
     }
 
     private static List<PathStat> convertTopItems(List<AnalysisResult.TopItem> items) {
@@ -144,13 +161,24 @@ public record AnalysisResponse(
             String city,
             String organization) {}
 
-    public record ParseErrors(
-            int errorCount,
-            List<String> errorSamples) {
-        public ParseErrors {
-            errorSamples = List.copyOf(errorSamples);
+    public record ParseStatisticsDto(
+            long totalLines,
+            long successCount,
+            long errorCount,
+            Map<String, Integer> errorsByType,
+            List<ParseErrorDto> errorSamples) {
+
+        public ParseStatisticsDto {
+            errorsByType = (errorsByType != null) ? Map.copyOf(errorsByType) : Map.of();
+            errorSamples = (errorSamples != null) ? List.copyOf(errorSamples) : List.of();
         }
     }
+
+    public record ParseErrorDto(
+            long lineNumber,
+            String errorMessage,
+            String errorType,
+            LocalDateTime occurredAt) {}
 
     public record AdditionalStats(
             Map<String, Long> methodStats,

--- a/src/main/java/com/electricip/loganalyzer/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/electricip/loganalyzer/api/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.electricip.loganalyzer.api;
 
+import com.electricip.loganalyzer.domain.InvalidCsvFormatException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -74,6 +75,44 @@ public class GlobalExceptionHandler {
                 ));
     }
     
+    /**
+     * InvalidCsvFormatException 처리
+     */
+    @ExceptionHandler(InvalidCsvFormatException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidCsvFormat(
+            InvalidCsvFormatException e, HttpServletRequest request) {
+
+        log.error("잘못된 CSV 형식: {}", e.getMessage());
+
+        return ResponseEntity
+                .badRequest()
+                .body(ErrorResponse.of(
+                        HttpStatus.BAD_REQUEST,
+                        "INVALID_CSV_FORMAT",
+                        e.getMessage(),
+                        request.getRequestURI()
+                ));
+    }
+
+    /**
+     * IllegalStateException 처리
+     */
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalState(
+            IllegalStateException e, HttpServletRequest request) {
+
+        log.error("잘못된 상태: {}", e.getMessage());
+
+        return ResponseEntity
+                .status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(ErrorResponse.of(
+                        HttpStatus.UNPROCESSABLE_ENTITY,
+                        "INVALID_STATE",
+                        e.getMessage(),
+                        request.getRequestURI()
+                ));
+    }
+
     /**
      * 일반 예외
      */

--- a/src/main/java/com/electricip/loganalyzer/application/AnalysisService.java
+++ b/src/main/java/com/electricip/loganalyzer/application/AnalysisService.java
@@ -1,6 +1,7 @@
 package com.electricip.loganalyzer.application;
 
 import com.electricip.loganalyzer.domain.AnalysisResult;
+import com.electricip.loganalyzer.domain.InvalidCsvFormatException;
 import com.electricip.loganalyzer.domain.IpInfo;
 import com.electricip.loganalyzer.infrastructure.client.IpInfoClient;
 import com.electricip.loganalyzer.infrastructure.parser.CsvLogParser;
@@ -53,13 +54,13 @@ public class AnalysisService {
             if (logs.isEmpty()) {
                 throw new IllegalStateException("유효한 로그가 없습니다");
             }
-            
+
             // 2. 통계 계산
             var statistics = statisticsCalculator.calculate(logs);
-            
+
             // 3. IP enrichment
             var ipDetails = enrichIpInfo(statistics.topIps());
-            
+
             // 4. 결과 생성
             var result = AnalysisResult.builder()
                     .analysisId(UUID.randomUUID().toString())
@@ -67,21 +68,22 @@ public class AnalysisService {
                     .processingTimeMs(System.currentTimeMillis() - startTime)
                     .statistics(statistics)
                     .ipDetails(ipDetails)
-                    .parseErrors(new AnalysisResult.ParseErrors(
-                            parseResult.errorCount(),
-                            parseResult.errorSamples()))
+                    .parseStatistics(parseResult.parseStatistics())
                     .build();
-            
+
             // 5. 저장
             repository.save(result);
-            
-            log.info("분석 완료: id={}, duration={}ms, total={}", 
-                    result.getAnalysisId(), 
+
+            log.info("분석 완료: id={}, duration={}ms, total={}",
+                    result.getAnalysisId(),
                     result.getProcessingTimeMs(),
                     statistics.totalRequests());
-            
+
             return result;
-            
+
+        } catch (InvalidCsvFormatException | IllegalArgumentException | IllegalStateException e) {
+            log.error("분석 실패: {}", e.getMessage(), e);
+            throw e;
         } catch (Exception e) {
             log.error("분석 실패: {}", e.getMessage(), e);
             throw new RuntimeException("로그 분석에 실패했습니다: " + e.getMessage(), e);

--- a/src/main/java/com/electricip/loganalyzer/domain/AnalysisResult.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/AnalysisResult.java
@@ -3,7 +3,6 @@ package com.electricip.loganalyzer.domain;
 import lombok.*;
 
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -21,7 +20,7 @@ public class AnalysisResult {
     @Singular("ipDetail")
     Map<String, IpInfo> ipDetails;
 
-    ParseErrors parseErrors;
+    ParseStatistics parseStatistics;
 
     /**
      * 명시적 생성자
@@ -32,7 +31,7 @@ public class AnalysisResult {
             Long processingTimeMs,
             @NonNull Statistics statistics,
             Map<String, IpInfo> ipDetails,
-            ParseErrors parseErrors
+            ParseStatistics parseStatistics
     ) {
         this.analysisId = analysisId;
         this.completedAt = completedAt;
@@ -42,7 +41,7 @@ public class AnalysisResult {
         this.ipDetails = (ipDetails == null) ? Map.of() : Map.copyOf(ipDetails);
 
         // 기본값 보장
-        this.parseErrors = (parseErrors == null) ? ParseErrors.empty() : parseErrors;
+        this.parseStatistics = (parseStatistics == null) ? ParseStatistics.empty() : parseStatistics;
     }
 
 
@@ -113,20 +112,4 @@ public class AnalysisResult {
         }
     }
 
-    /**
-     * 파싱 오류 (Record)
-     */
-    public record ParseErrors(int errorCount, List<String> errorSamples) {
-        public static ParseErrors empty() {
-            return new ParseErrors(0, Collections.emptyList());
-        }
-
-        public ParseErrors {
-            errorSamples = List.copyOf(errorSamples);
-        }
-
-        public List<String> errorSamples() {
-            return errorSamples; // 이미 불변
-        }
-    }
 }

--- a/src/main/java/com/electricip/loganalyzer/domain/InvalidCsvFormatException.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/InvalidCsvFormatException.java
@@ -1,0 +1,24 @@
+package com.electricip.loganalyzer.domain;
+
+import java.util.List;
+
+/**
+ * CSV 형식이 올바르지 않을 때 발생하는 도메인 예외
+ */
+public class InvalidCsvFormatException extends RuntimeException {
+
+    private final List<String> missingHeaders;
+
+    public InvalidCsvFormatException(String message, List<String> missingHeaders) {
+        super(message);
+        this.missingHeaders = (missingHeaders != null) ? List.copyOf(missingHeaders) : List.of();
+    }
+
+    public InvalidCsvFormatException(String message) {
+        this(message, List.of());
+    }
+
+    public List<String> getMissingHeaders() {
+        return missingHeaders;
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/domain/ParseError.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/ParseError.java
@@ -1,0 +1,28 @@
+package com.electricip.loganalyzer.domain;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+/**
+ * 파싱 에러 정보 (Value Object)
+ */
+public record ParseError(long lineNumber, String errorMessage, ErrorType errorType, LocalDateTime occurredAt) {
+
+    public enum ErrorType {
+        PARSING,
+        VALIDATION,
+        FORMAT
+    }
+
+    /**
+     * Compact Constructor: 필수 필드 검증
+     */
+    public ParseError {
+        if (lineNumber < 1) {
+            throw new IllegalArgumentException("lineNumber는 1 이상이어야 합니다");
+        }
+        Objects.requireNonNull(errorMessage, "errorMessage는 null일 수 없습니다");
+        Objects.requireNonNull(errorType, "errorType은 null일 수 없습니다");
+        Objects.requireNonNull(occurredAt, "occurredAt은 null일 수 없습니다");
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/domain/ParseStatistics.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/ParseStatistics.java
@@ -1,0 +1,42 @@
+package com.electricip.loganalyzer.domain;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 파싱 통계 (Value Object)
+ */
+public record ParseStatistics(
+        long totalLines,
+        long successCount,
+        long errorCount,
+        Map<String, Integer> errorsByType,
+        List<ParseError> errorSamples
+) {
+
+    public static final int MAX_ERROR_SAMPLES = 10;
+
+    /**
+     * Compact Constructor: 음수 검증 + 방어적 복사
+     */
+    public ParseStatistics {
+        if (totalLines < 0) {
+            throw new IllegalArgumentException("totalLines는 음수일 수 없습니다");
+        }
+        if (successCount < 0) {
+            throw new IllegalArgumentException("successCount는 음수일 수 없습니다");
+        }
+        if (errorCount < 0) {
+            throw new IllegalArgumentException("errorCount는 음수일 수 없습니다");
+        }
+        errorsByType = (errorsByType != null) ? Map.copyOf(errorsByType) : Map.of();
+        errorSamples = (errorSamples != null) ? List.copyOf(errorSamples) : List.of();
+    }
+
+    /**
+     * 빈 ParseStatistics 팩터리 메서드
+     */
+    public static ParseStatistics empty() {
+        return new ParseStatistics(0, 0, 0, Map.of(), List.of());
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/parser/CsvLogParser.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/parser/CsvLogParser.java
@@ -1,9 +1,11 @@
 package com.electricip.loganalyzer.infrastructure.parser;
 
 import com.electricip.loganalyzer.domain.AccessLog;
+import com.electricip.loganalyzer.domain.InvalidCsvFormatException;
+import com.electricip.loganalyzer.domain.ParseError;
+import com.electricip.loganalyzer.domain.ParseStatistics;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.io.input.BOMInputStream;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,11 +17,8 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
+import java.time.format.DateTimeParseException;
+import java.util.*;
 
 /**
  * CSV 로그 파서
@@ -27,74 +26,134 @@ import java.util.Objects;
 @Slf4j
 @Component
 public class CsvLogParser {
-    
-    private static final int MAX_ERROR_SAMPLES = 5;
-    private static final DateTimeFormatter FORMATTER = 
+
+    private static final DateTimeFormatter FORMATTER =
             DateTimeFormatter.ofPattern("M/d/yyyy, h:mm:ss.SSS a", Locale.ENGLISH);
-    
+
+    private static final Set<String> REQUIRED_HEADERS = Set.of(
+            "TimeGenerated [UTC]",
+            "ClientIp",
+            "HttpMethod",
+            "RequestUri",
+            "UserAgent",
+            "HttpStatus",
+            "HttpVersion",
+            "ReceivedBytes",
+            "SentBytes",
+            "ClientResponseTime",
+            "SslProtocol",
+            "OriginalRequestUriWithArgs"
+    );
+
     @Value("${log-analysis.max-file-lines:200000}")
     private int maxFileLines;
-    
+
     /**
      * CSV 파일 파싱
-     * 
+     *
      * @param inputStream CSV 입력 스트림
      * @return 파싱 결과
      * @throws NullPointerException inputStream이 null인 경우
-     * @throws RuntimeException 파싱 실패 시
+     * @throws InvalidCsvFormatException 헤더가 올바르지 않거나 파싱 실패 시
      */
     public ParseResult parse(InputStream inputStream) {
         Objects.requireNonNull(inputStream, "inputStream은 null일 수 없습니다");
-        
+
         var logs = new ArrayList<AccessLog>();
-        var errorSamples = new ArrayList<String>();
+        var errorSamples = new ArrayList<ParseError>();
+        var errorsByType = new HashMap<String, Integer>();
         var errorCount = 0;
         var lineNumber = 0;
-        
-        // try-with-resources
+
         try (var reader = new BufferedReader(
                 new InputStreamReader(new BOMInputStream(inputStream), StandardCharsets.UTF_8))) {
-            
+
             var csvFormat = CSVFormat.DEFAULT.builder()
                     .setHeader()
                     .setSkipHeaderRecord(true)
                     .setIgnoreHeaderCase(true)
                     .setTrim(true)
                     .build();
-            
+
             try (var csvParser = csvFormat.parse(reader)) {
+                validateHeaders(csvParser.getHeaderMap());
+
                 for (CSVRecord record : csvParser) {
                     lineNumber++;
-                    
+
                     if (lineNumber > maxFileLines) {
                         log.warn("최대 라인 수 도달: {}", maxFileLines);
                         break;
                     }
-                    
+
                     try {
                         var accessLog = parseRecord(record);
                         logs.add(accessLog);
                     } catch (Exception e) {
                         errorCount++;
-                        if (errorSamples.size() < MAX_ERROR_SAMPLES) {
-                            errorSamples.add(String.format("Line %d: %s", 
-                                    lineNumber, e.getMessage()));
+                        var errorType = classifyError(e);
+                        errorsByType.merge(errorType.name(), 1, Integer::sum);
+
+                        if (errorSamples.size() < ParseStatistics.MAX_ERROR_SAMPLES) {
+                            errorSamples.add(new ParseError(
+                                    lineNumber,
+                                    e.getMessage(),
+                                    errorType,
+                                    LocalDateTime.now()
+                            ));
                         }
                     }
                 }
             }
-            
-            log.info("파싱 완료: total={}, success={}, errors={}", 
+
+            log.info("파싱 완료: total={}, success={}, errors={}",
                     lineNumber, logs.size(), errorCount);
-            
-            return new ParseResult(logs, errorCount, errorSamples);
-            
+
+            var parseStatistics = new ParseStatistics(
+                    lineNumber, logs.size(), errorCount, errorsByType, errorSamples);
+
+            return new ParseResult(logs, parseStatistics);
+
+        } catch (InvalidCsvFormatException e) {
+            throw e;
         } catch (Exception e) {
             log.error("CSV 파싱 실패", e);
-            throw new RuntimeException("CSV 파일 파싱 실패: " + e.getMessage(), e);
+            throw new InvalidCsvFormatException("CSV 파일 파싱 실패: " + e.getMessage());
         }
     }
-    
+
+    /**
+     * 헤더 검증 — 대소문자 무시 비교, 누락 시 InvalidCsvFormatException 발생
+     */
+    private void validateHeaders(Map<String, Integer> headerMap) {
+        var actualHeaders = headerMap.keySet().stream()
+                .map(String::toLowerCase)
+                .collect(java.util.stream.Collectors.toSet());
+
+        var missingHeaders = REQUIRED_HEADERS.stream()
+                .filter(required -> !actualHeaders.contains(required.toLowerCase()))
+                .sorted()
+                .toList();
+
+        if (!missingHeaders.isEmpty()) {
+            throw new InvalidCsvFormatException(
+                    "필수 헤더가 누락되었습니다: " + missingHeaders, missingHeaders);
+        }
+    }
+
+    /**
+     * 에러 타입 분류
+     */
+    private ParseError.ErrorType classifyError(Exception e) {
+        if (e instanceof NumberFormatException || e instanceof DateTimeParseException) {
+            return ParseError.ErrorType.PARSING;
+        }
+        if (e instanceof IllegalArgumentException) {
+            return ParseError.ErrorType.VALIDATION;
+        }
+        return ParseError.ErrorType.FORMAT;
+    }
+
     /**
      * CSV 레코드를 AccessLog로 변환
      */
@@ -114,7 +173,7 @@ public class CsvLogParser {
                 record.get("OriginalRequestUriWithArgs")
         );
     }
-    
+
     private LocalDateTime parseDateTime(String value) {
         if (value == null || value.isBlank()) return null;
         try {
@@ -123,7 +182,7 @@ public class CsvLogParser {
             return null;
         }
     }
-    
+
     private Integer parseInteger(String value) {
         if (value == null || value.isBlank()) return null;
         try {
@@ -132,7 +191,7 @@ public class CsvLogParser {
             return null;
         }
     }
-    
+
     private Long parseLong(String value) {
         if (value == null || value.isBlank()) return null;
         try {
@@ -141,7 +200,7 @@ public class CsvLogParser {
             return null;
         }
     }
-    
+
     private Double parseDouble(String value) {
         if (value == null || value.isBlank()) return null;
         try {
@@ -150,21 +209,17 @@ public class CsvLogParser {
             return null;
         }
     }
-    
+
     /**
      * 파싱 결과 (Record)
      */
     public record ParseResult(
             List<AccessLog> logs,
-            int errorCount,
-            List<String> errorSamples
+            ParseStatistics parseStatistics
     ) {
-        /**
-         * 가변 컬렉션을 불변으로 변환
-         */
         public ParseResult {
             logs = List.copyOf(logs);
-            errorSamples = List.copyOf(errorSamples);
+            Objects.requireNonNull(parseStatistics, "parseStatistics는 null일 수 없습니다");
         }
     }
 }

--- a/src/test/java/com/electricip/loganalyzer/api/AnalysisResponseTest.java
+++ b/src/test/java/com/electricip/loganalyzer/api/AnalysisResponseTest.java
@@ -20,8 +20,8 @@ class AnalysisResponseTest {
                 Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
     }
 
-    private static AnalysisResponse.ParseErrors validParseErrors() {
-        return new AnalysisResponse.ParseErrors(0, Collections.emptyList());
+    private static AnalysisResponse.ParseStatisticsDto validParseStatistics() {
+        return new AnalysisResponse.ParseStatisticsDto(0, 0, 0, Map.of(), Collections.emptyList());
     }
 
     private static AnalysisResponse.AdditionalStats validAdditionalStats() {
@@ -37,7 +37,7 @@ class AnalysisResponseTest {
                 .basicStats(validBasicStats())
                 .topStats(validTopStats())
                 .ipDetails(Collections.emptyList())
-                .parseErrors(validParseErrors())
+                .parseStatistics(validParseStatistics())
                 .additionalStats(validAdditionalStats())
                 .build();
 
@@ -55,7 +55,7 @@ class AnalysisResponseTest {
                         .basicStats(validBasicStats())
                         .topStats(validTopStats())
                         .ipDetails(Collections.emptyList())
-                        .parseErrors(validParseErrors())
+                        .parseStatistics(validParseStatistics())
                         .additionalStats(validAdditionalStats())
                         .build());
     }
@@ -69,7 +69,7 @@ class AnalysisResponseTest {
                         .basicStats(validBasicStats())
                         .topStats(validTopStats())
                         .ipDetails(Collections.emptyList())
-                        .parseErrors(validParseErrors())
+                        .parseStatistics(validParseStatistics())
                         .additionalStats(validAdditionalStats())
                         .build());
     }
@@ -83,7 +83,7 @@ class AnalysisResponseTest {
                         .completedAt(LocalDateTime.now())
                         .topStats(validTopStats())
                         .ipDetails(Collections.emptyList())
-                        .parseErrors(validParseErrors())
+                        .parseStatistics(validParseStatistics())
                         .additionalStats(validAdditionalStats())
                         .build());
     }
@@ -97,7 +97,7 @@ class AnalysisResponseTest {
                 .basicStats(validBasicStats())
                 .topStats(validTopStats())
                 .ipDetails(Collections.emptyList())
-                .parseErrors(validParseErrors())
+                .parseStatistics(validParseStatistics())
                 .additionalStats(validAdditionalStats())
                 .build();
 

--- a/src/test/java/com/electricip/loganalyzer/api/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/electricip/loganalyzer/api/GlobalExceptionHandlerTest.java
@@ -1,0 +1,105 @@
+package com.electricip.loganalyzer.api;
+
+import com.electricip.loganalyzer.domain.InvalidCsvFormatException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+    private final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/analysis");
+
+    @Nested
+    @DisplayName("InvalidCsvFormatException 핸들러")
+    class InvalidCsvFormatExceptionTest {
+
+        @Test
+        @DisplayName("400 Bad Request로 응답한다")
+        void shouldReturn400() {
+            var ex = new InvalidCsvFormatException("필수 헤더가 누락되었습니다", List.of("ClientIp"));
+
+            var response = handler.handleInvalidCsvFormat(ex, request);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().errorCode()).isEqualTo("INVALID_CSV_FORMAT");
+            assertThat(response.getBody().message()).contains("헤더가 누락");
+        }
+
+        @Test
+        @DisplayName("경로 정보가 응답에 포함된다")
+        void shouldIncludePathInResponse() {
+            var ex = new InvalidCsvFormatException("test");
+
+            var response = handler.handleInvalidCsvFormat(ex, request);
+
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().path()).isEqualTo("/api/analysis");
+        }
+    }
+
+    @Nested
+    @DisplayName("IllegalStateException 핸들러")
+    class IllegalStateExceptionTest {
+
+        @Test
+        @DisplayName("422 Unprocessable Entity로 응답한다")
+        void shouldReturn422() {
+            var ex = new IllegalStateException("유효한 로그가 없습니다");
+
+            var response = handler.handleIllegalState(ex, request);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().errorCode()).isEqualTo("INVALID_STATE");
+            assertThat(response.getBody().message()).isEqualTo("유효한 로그가 없습니다");
+        }
+
+        @Test
+        @DisplayName("상태 코드가 422이다")
+        void shouldHaveStatusCode422() {
+            var ex = new IllegalStateException("test");
+
+            var response = handler.handleIllegalState(ex, request);
+
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().status()).isEqualTo(422);
+        }
+    }
+
+    @Nested
+    @DisplayName("기존 핸들러 정상 동작 확인")
+    class ExistingHandlersTest {
+
+        @Test
+        @DisplayName("IllegalArgumentException은 400으로 응답한다")
+        void shouldReturn400ForIllegalArgument() {
+            var ex = new IllegalArgumentException("파일이 비어있습니다");
+
+            var response = handler.handleIllegalArgument(ex, request);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().errorCode()).isEqualTo("INVALID_REQUEST");
+        }
+
+        @Test
+        @DisplayName("일반 Exception은 500으로 응답한다")
+        void shouldReturn500ForGenericException() {
+            var ex = new RuntimeException("알 수 없는 오류");
+
+            var response = handler.handleException(ex, request);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().errorCode()).isEqualTo("INTERNAL_ERROR");
+        }
+    }
+}

--- a/src/test/java/com/electricip/loganalyzer/domain/AnalysisResultTest.java
+++ b/src/test/java/com/electricip/loganalyzer/domain/AnalysisResultTest.java
@@ -117,17 +117,20 @@ class AnalysisResultTest {
         }
 
         @Test
-        @DisplayName("parseErrors 미설정 시 empty가 기본값")
-        void shouldDefaultParseErrorsToEmpty() {
+        @DisplayName("parseStatistics 미설정 시 empty가 기본값")
+        void shouldDefaultParseStatisticsToEmpty() {
             var result = AnalysisResult.builder()
                     .analysisId("test-id")
                     .completedAt(LocalDateTime.now())
                     .statistics(validStatistics())
                     .build();
 
-            assertThat(result.getParseErrors()).isNotNull();
-            assertThat(result.getParseErrors().errorCount()).isZero();
-            assertThat(result.getParseErrors().errorSamples()).isEmpty();
+            assertThat(result.getParseStatistics()).isNotNull();
+            assertThat(result.getParseStatistics().totalLines()).isZero();
+            assertThat(result.getParseStatistics().successCount()).isZero();
+            assertThat(result.getParseStatistics().errorCount()).isZero();
+            assertThat(result.getParseStatistics().errorsByType()).isEmpty();
+            assertThat(result.getParseStatistics().errorSamples()).isEmpty();
         }
 
         @Test
@@ -383,56 +386,43 @@ class AnalysisResultTest {
     }
 
     @Nested
-    @DisplayName("ParseErrors 검증")
-    class ParseErrorsTest {
+    @DisplayName("ParseStatistics 기본값 검증")
+    class ParseStatisticsDefaultTest {
 
         @Test
-        @DisplayName("empty()는 errorCount 0, 빈 리스트를 반환한다")
-        void shouldCreateEmptyParseErrors() {
-            var errors = AnalysisResult.ParseErrors.empty();
+        @DisplayName("null 전달 시 empty ParseStatistics가 설정된다")
+        void shouldDefaultToEmptyWhenNull() {
+            var result = new AnalysisResult(
+                    "test-id",
+                    LocalDateTime.now(),
+                    null,
+                    validStatistics(),
+                    null,
+                    null
+            );
 
-            assertThat(errors.errorCount()).isZero();
-            assertThat(errors.errorSamples()).isEmpty();
+            assertThat(result.getParseStatistics()).isNotNull();
+            assertThat(result.getParseStatistics().totalLines()).isZero();
+            assertThat(result.getParseStatistics().errorCount()).isZero();
+            assertThat(result.getParseStatistics().errorSamples()).isEmpty();
         }
 
         @Test
-        @DisplayName("정상 값으로 생성된다")
-        void shouldCreateWithValues() {
-            var samples = List.of("error1", "error2");
-            var errors = new AnalysisResult.ParseErrors(2, samples);
+        @DisplayName("ParseStatistics 전달 시 그대로 설정된다")
+        void shouldUseProvidedParseStatistics() {
+            var stats = new ParseStatistics(10, 9, 1, Map.of("PARSING", 1), List.of());
+            var result = new AnalysisResult(
+                    "test-id",
+                    LocalDateTime.now(),
+                    null,
+                    validStatistics(),
+                    null,
+                    stats
+            );
 
-            assertThat(errors.errorCount()).isEqualTo(2);
-            assertThat(errors.errorSamples()).containsExactly("error1", "error2");
-        }
-
-        @Test
-        @DisplayName("errorSamples는 방어적 복사로 불변이다")
-        void shouldDefensivelyCopyErrorSamples() {
-            var mutableList = new ArrayList<>(List.of("error1"));
-            var errors = new AnalysisResult.ParseErrors(1, mutableList);
-
-            mutableList.clear();
-
-            assertThat(errors.errorSamples()).hasSize(1);
-            assertThat(errors.errorSamples().get(0)).isEqualTo("error1");
-        }
-
-        @Test
-        @DisplayName("errorSamples 반환 리스트는 수정할 수 없다")
-        void shouldReturnUnmodifiableErrorSamples() {
-            var errors = new AnalysisResult.ParseErrors(1, List.of("error1"));
-
-            assertThatThrownBy(() -> errors.errorSamples().clear())
-                    .isInstanceOf(UnsupportedOperationException.class);
-        }
-
-        @Test
-        @DisplayName("empty()의 errorSamples도 수정할 수 없다")
-        void shouldReturnUnmodifiableEmptyErrorSamples() {
-            var errors = AnalysisResult.ParseErrors.empty();
-
-            assertThatThrownBy(() -> errors.errorSamples().add("hack"))
-                    .isInstanceOf(UnsupportedOperationException.class);
+            assertThat(result.getParseStatistics().totalLines()).isEqualTo(10);
+            assertThat(result.getParseStatistics().successCount()).isEqualTo(9);
+            assertThat(result.getParseStatistics().errorCount()).isEqualTo(1);
         }
     }
 }

--- a/src/test/java/com/electricip/loganalyzer/domain/InvalidCsvFormatExceptionTest.java
+++ b/src/test/java/com/electricip/loganalyzer/domain/InvalidCsvFormatExceptionTest.java
@@ -1,0 +1,79 @@
+package com.electricip.loganalyzer.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class InvalidCsvFormatExceptionTest {
+
+    @Nested
+    @DisplayName("생성자 검증")
+    class ConstructorTest {
+
+        @Test
+        @DisplayName("메시지와 누락 헤더 리스트로 생성된다")
+        void shouldCreateWithMessageAndMissingHeaders() {
+            var headers = List.of("ClientIp", "HttpMethod");
+            var ex = new InvalidCsvFormatException("헤더 누락", headers);
+
+            assertThat(ex.getMessage()).isEqualTo("헤더 누락");
+            assertThat(ex.getMissingHeaders()).containsExactly("ClientIp", "HttpMethod");
+        }
+
+        @Test
+        @DisplayName("메시지만으로 생성 시 빈 missingHeaders")
+        void shouldCreateWithMessageOnly() {
+            var ex = new InvalidCsvFormatException("파싱 실패");
+
+            assertThat(ex.getMessage()).isEqualTo("파싱 실패");
+            assertThat(ex.getMissingHeaders()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("null missingHeaders는 빈 리스트로 처리된다")
+        void shouldHandleNullMissingHeaders() {
+            var ex = new InvalidCsvFormatException("message", null);
+
+            assertThat(ex.getMissingHeaders()).isNotNull().isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("불변성 검증")
+    class ImmutabilityTest {
+
+        @Test
+        @DisplayName("원본 리스트 수정이 missingHeaders에 영향 없다")
+        void shouldDefensivelyCopyMissingHeaders() {
+            var mutableList = new ArrayList<>(List.of("ClientIp"));
+            var ex = new InvalidCsvFormatException("msg", mutableList);
+
+            mutableList.clear();
+
+            assertThat(ex.getMissingHeaders()).hasSize(1);
+            assertThat(ex.getMissingHeaders().get(0)).isEqualTo("ClientIp");
+        }
+
+        @Test
+        @DisplayName("반환된 missingHeaders 리스트는 수정할 수 없다")
+        void shouldReturnUnmodifiableMissingHeaders() {
+            var ex = new InvalidCsvFormatException("msg", List.of("ClientIp"));
+
+            assertThatThrownBy(() -> ex.getMissingHeaders().clear())
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Test
+    @DisplayName("RuntimeException을 상속한다")
+    void shouldExtendRuntimeException() {
+        var ex = new InvalidCsvFormatException("test");
+        assertThat(ex).isInstanceOf(RuntimeException.class);
+    }
+}

--- a/src/test/java/com/electricip/loganalyzer/domain/ParseErrorTest.java
+++ b/src/test/java/com/electricip/loganalyzer/domain/ParseErrorTest.java
@@ -1,0 +1,87 @@
+package com.electricip.loganalyzer.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ParseErrorTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2025, 1, 1, 0, 0);
+
+    @Nested
+    @DisplayName("ParseError 생성 검증")
+    class ConstructorTest {
+
+        @Test
+        @DisplayName("정상 값으로 생성된다")
+        void shouldCreateWithValidValues() {
+            var error = new ParseError(1, "test error", ParseError.ErrorType.PARSING, NOW);
+
+            assertThat(error.lineNumber()).isEqualTo(1);
+            assertThat(error.errorMessage()).isEqualTo("test error");
+            assertThat(error.errorType()).isEqualTo(ParseError.ErrorType.PARSING);
+            assertThat(error.occurredAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("lineNumber가 0이면 IllegalArgumentException 발생")
+        void shouldThrowWhenLineNumberIsZero() {
+            assertThatThrownBy(() -> new ParseError(0, "msg", ParseError.ErrorType.PARSING, NOW))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("lineNumber");
+        }
+
+        @Test
+        @DisplayName("lineNumber가 음수이면 IllegalArgumentException 발생")
+        void shouldThrowWhenLineNumberIsNegative() {
+            assertThatThrownBy(() -> new ParseError(-1, "msg", ParseError.ErrorType.PARSING, NOW))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("lineNumber");
+        }
+
+        @Test
+        @DisplayName("errorMessage가 null이면 NullPointerException 발생")
+        void shouldThrowWhenErrorMessageIsNull() {
+            assertThatThrownBy(() -> new ParseError(1, null, ParseError.ErrorType.PARSING, NOW))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("errorMessage");
+        }
+
+        @Test
+        @DisplayName("errorType이 null이면 NullPointerException 발생")
+        void shouldThrowWhenErrorTypeIsNull() {
+            assertThatThrownBy(() -> new ParseError(1, "msg", null, NOW))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("errorType");
+        }
+
+        @Test
+        @DisplayName("occurredAt이 null이면 NullPointerException 발생")
+        void shouldThrowWhenOccurredAtIsNull() {
+            assertThatThrownBy(() -> new ParseError(1, "msg", ParseError.ErrorType.PARSING, null))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("occurredAt");
+        }
+    }
+
+    @Nested
+    @DisplayName("ErrorType 검증")
+    class ErrorTypeTest {
+
+        @Test
+        @DisplayName("모든 ErrorType 값이 존재한다")
+        void shouldHaveAllErrorTypes() {
+            assertThat(ParseError.ErrorType.values())
+                    .containsExactlyInAnyOrder(
+                            ParseError.ErrorType.PARSING,
+                            ParseError.ErrorType.VALIDATION,
+                            ParseError.ErrorType.FORMAT
+                    );
+        }
+    }
+}

--- a/src/test/java/com/electricip/loganalyzer/domain/ParseStatisticsTest.java
+++ b/src/test/java/com/electricip/loganalyzer/domain/ParseStatisticsTest.java
@@ -1,0 +1,157 @@
+package com.electricip.loganalyzer.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ParseStatisticsTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2025, 1, 1, 0, 0);
+
+    @Nested
+    @DisplayName("ParseStatistics 생성 검증")
+    class ConstructorTest {
+
+        @Test
+        @DisplayName("정상 값으로 생성된다")
+        void shouldCreateWithValidValues() {
+            var errors = List.of(new ParseError(1, "err", ParseError.ErrorType.PARSING, NOW));
+            var stats = new ParseStatistics(10, 9, 1, Map.of("PARSING", 1), errors);
+
+            assertThat(stats.totalLines()).isEqualTo(10);
+            assertThat(stats.successCount()).isEqualTo(9);
+            assertThat(stats.errorCount()).isEqualTo(1);
+            assertThat(stats.errorsByType()).containsEntry("PARSING", 1);
+            assertThat(stats.errorSamples()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("totalLines가 음수이면 IllegalArgumentException 발생")
+        void shouldThrowWhenTotalLinesIsNegative() {
+            assertThatThrownBy(() -> new ParseStatistics(-1, 0, 0, Map.of(), List.of()))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("totalLines");
+        }
+
+        @Test
+        @DisplayName("successCount가 음수이면 IllegalArgumentException 발생")
+        void shouldThrowWhenSuccessCountIsNegative() {
+            assertThatThrownBy(() -> new ParseStatistics(0, -1, 0, Map.of(), List.of()))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("successCount");
+        }
+
+        @Test
+        @DisplayName("errorCount가 음수이면 IllegalArgumentException 발생")
+        void shouldThrowWhenErrorCountIsNegative() {
+            assertThatThrownBy(() -> new ParseStatistics(0, 0, -1, Map.of(), List.of()))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("errorCount");
+        }
+
+        @Test
+        @DisplayName("errorsByType가 null이면 빈 맵이 기본값")
+        void shouldDefaultErrorsByTypeToEmptyMap() {
+            var stats = new ParseStatistics(0, 0, 0, null, List.of());
+            assertThat(stats.errorsByType()).isNotNull().isEmpty();
+        }
+
+        @Test
+        @DisplayName("errorSamples가 null이면 빈 리스트가 기본값")
+        void shouldDefaultErrorSamplesToEmptyList() {
+            var stats = new ParseStatistics(0, 0, 0, Map.of(), null);
+            assertThat(stats.errorSamples()).isNotNull().isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("ParseStatistics 불변성 검증")
+    class ImmutabilityTest {
+
+        @Test
+        @DisplayName("원본 맵 수정이 내부 상태에 영향 없다")
+        void shouldDefensivelyCopyErrorsByType() {
+            var mutableMap = new HashMap<String, Integer>();
+            mutableMap.put("PARSING", 1);
+
+            var stats = new ParseStatistics(1, 0, 1, mutableMap, List.of());
+            mutableMap.clear();
+
+            assertThat(stats.errorsByType()).hasSize(1);
+            assertThat(stats.errorsByType().get("PARSING")).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("원본 리스트 수정이 내부 상태에 영향 없다")
+        void shouldDefensivelyCopyErrorSamples() {
+            var mutableList = new ArrayList<>(List.of(
+                    new ParseError(1, "err", ParseError.ErrorType.PARSING, NOW)));
+
+            var stats = new ParseStatistics(1, 0, 1, Map.of(), mutableList);
+            mutableList.clear();
+
+            assertThat(stats.errorSamples()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("errorsByType 반환 맵은 수정할 수 없다")
+        void shouldReturnUnmodifiableErrorsByType() {
+            var stats = new ParseStatistics(1, 0, 1, Map.of("PARSING", 1), List.of());
+
+            assertThatThrownBy(() -> stats.errorsByType().clear())
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        @DisplayName("errorSamples 반환 리스트는 수정할 수 없다")
+        void shouldReturnUnmodifiableErrorSamples() {
+            var error = new ParseError(1, "err", ParseError.ErrorType.PARSING, NOW);
+            var stats = new ParseStatistics(1, 0, 1, Map.of(), List.of(error));
+
+            assertThatThrownBy(() -> stats.errorSamples().clear())
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("empty() 팩터리 메서드 검증")
+    class EmptyFactoryTest {
+
+        @Test
+        @DisplayName("empty()는 모든 값이 0/빈 상태이다")
+        void shouldCreateEmptyParseStatistics() {
+            var stats = ParseStatistics.empty();
+
+            assertThat(stats.totalLines()).isZero();
+            assertThat(stats.successCount()).isZero();
+            assertThat(stats.errorCount()).isZero();
+            assertThat(stats.errorsByType()).isEmpty();
+            assertThat(stats.errorSamples()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("empty()의 컬렉션도 수정할 수 없다")
+        void shouldReturnUnmodifiableCollectionsFromEmpty() {
+            var stats = ParseStatistics.empty();
+
+            assertThatThrownBy(() -> stats.errorSamples().add(
+                    new ParseError(1, "err", ParseError.ErrorType.PARSING, NOW)))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Test
+    @DisplayName("MAX_ERROR_SAMPLES 상수는 10이다")
+    void shouldHaveMaxErrorSamplesOf10() {
+        assertThat(ParseStatistics.MAX_ERROR_SAMPLES).isEqualTo(10);
+    }
+}

--- a/src/test/java/com/electricip/loganalyzer/infrastructure/parser/CsvLogParserTest.java
+++ b/src/test/java/com/electricip/loganalyzer/infrastructure/parser/CsvLogParserTest.java
@@ -1,0 +1,143 @@
+package com.electricip.loganalyzer.infrastructure.parser;
+
+import com.electricip.loganalyzer.domain.InvalidCsvFormatException;
+import com.electricip.loganalyzer.domain.ParseError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CsvLogParserTest {
+
+    private CsvLogParser parser;
+
+    private static final String VALID_HEADERS = String.join(",",
+            "TimeGenerated [UTC]", "ClientIp", "HttpMethod", "RequestUri",
+            "UserAgent", "HttpStatus", "HttpVersion", "ReceivedBytes",
+            "SentBytes", "ClientResponseTime", "SslProtocol",
+            "OriginalRequestUriWithArgs");
+
+    private static final String VALID_ROW =
+            "1/1/2025, 12:00:00.000 AM,1.2.3.4,GET,/api/test,Mozilla/5.0,200,HTTP/1.1,100,200,0.5,TLSv1.2,/api/test?q=1";
+
+    @BeforeEach
+    void setUp() {
+        parser = new CsvLogParser();
+        ReflectionTestUtils.setField(parser, "maxFileLines", 200000);
+    }
+
+    private ByteArrayInputStream toStream(String csv) {
+        return new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Nested
+    @DisplayName("헤더 검증")
+    class HeaderValidationTest {
+
+        @Test
+        @DisplayName("유효한 헤더가 있으면 정상 파싱된다")
+        void shouldParseWithValidHeaders() {
+            var csv = VALID_HEADERS + "\n" + VALID_ROW;
+            var result = parser.parse(toStream(csv));
+
+            assertThat(result.logs()).hasSize(1);
+            assertThat(result.parseStatistics().totalLines()).isEqualTo(1);
+            assertThat(result.parseStatistics().successCount()).isEqualTo(1);
+            assertThat(result.parseStatistics().errorCount()).isZero();
+        }
+
+        @Test
+        @DisplayName("필수 헤더가 누락되면 InvalidCsvFormatException 발생")
+        void shouldThrowWhenRequiredHeadersMissing() {
+            var csv = "WrongHeader1,WrongHeader2\nval1,val2";
+
+            assertThatThrownBy(() -> parser.parse(toStream(csv)))
+                    .isInstanceOf(InvalidCsvFormatException.class)
+                    .hasMessageContaining("필수 헤더가 누락되었습니다");
+        }
+
+        @Test
+        @DisplayName("누락된 헤더 목록이 예외에 포함된다")
+        void shouldIncludeMissingHeadersInException() {
+            var csv = "TimeGenerated [UTC],ClientIp\nval1,val2";
+
+            try {
+                parser.parse(toStream(csv));
+            } catch (InvalidCsvFormatException e) {
+                assertThat(e.getMissingHeaders()).isNotEmpty();
+                assertThat(e.getMissingHeaders()).contains("HttpMethod", "RequestUri");
+            }
+        }
+
+        @Test
+        @DisplayName("헤더 대소문자가 달라도 정상 파싱된다")
+        void shouldParseWithCaseInsensitiveHeaders() {
+            var headers = VALID_HEADERS.toUpperCase();
+            var csv = headers + "\n" + VALID_ROW;
+
+            var result = parser.parse(toStream(csv));
+            assertThat(result.logs()).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("에러 분류 및 ParseStatistics 생성")
+    class ErrorClassificationTest {
+
+        @Test
+        @DisplayName("빈 CSV 데이터도 헤더만 있으면 빈 결과를 반환한다")
+        void shouldReturnEmptyResultWithHeadersOnly() {
+            var csv = VALID_HEADERS + "\n";
+            var result = parser.parse(toStream(csv));
+
+            assertThat(result.logs()).isEmpty();
+            assertThat(result.parseStatistics().totalLines()).isZero();
+            assertThat(result.parseStatistics().errorCount()).isZero();
+        }
+
+        @Test
+        @DisplayName("파싱 통계에 성공/에러 카운트가 포함된다")
+        void shouldTrackSuccessAndErrorCounts() {
+            var csv = VALID_HEADERS + "\n" + VALID_ROW + "\n" + VALID_ROW;
+            var result = parser.parse(toStream(csv));
+
+            assertThat(result.parseStatistics().totalLines()).isEqualTo(2);
+            assertThat(result.parseStatistics().successCount()).isEqualTo(2);
+            assertThat(result.parseStatistics().errorCount()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("null 입력 검증")
+    class NullInputTest {
+
+        @Test
+        @DisplayName("inputStream이 null이면 NullPointerException 발생")
+        void shouldThrowWhenInputStreamIsNull() {
+            assertThatThrownBy(() -> parser.parse(null))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("inputStream");
+        }
+    }
+
+    @Nested
+    @DisplayName("외부 예외 처리")
+    class ExternalExceptionTest {
+
+        @Test
+        @DisplayName("빈 스트림은 InvalidCsvFormatException 발생")
+        void shouldThrowInvalidCsvFormatOnEmptyStream() {
+            var csv = "";
+
+            assertThatThrownBy(() -> parser.parse(toStream(csv)))
+                    .isInstanceOf(InvalidCsvFormatException.class);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
CsvLogParser의 헤더 검증을 강화하고, 파싱 오류 정보를 ParseStatistics로 구조화하여
오류 원인 파악 가능성을 높였으며 도메인 예외가 API까지 올바르게 전파되도록 수정.

---

## Context

### Issue #10
- Issue: #10
- CsvLogParser의 헤더 검증이 부족하여 잘못된 CSV도 파싱을 시도했고, 에러가 불명확하게 발생함
- 파싱 오류 정보가 5개 문자열 샘플만 저장되어 에러 타입 분류/통계가 불가능했음
- AnalysisService가 모든 예외를 RuntimeException으로 감싸 도메인 예외가 GlobalExceptionHandler에 올바르게 전달되지 않았음

### Background
- 파서는 입력 포맷이 잘못된 경우 조기에 실패(fail-fast)해야 디버깅 비용이 줄어듦
- 오류는 “문자열 샘플”이 아니라 타입/라인/발생시각/통계로 구조화되어야 운영 및 분석에 유리함
- 도메인/입력 포맷 예외는 애플리케이션에서 삼키지 않고 그대로 전파되어 API에서 일관되게 매핑되어야 함
- 메모리 최적화(배치 처리)는 이번 범위에서 제외(이미 maxFileLines=200000 제한 존재)

---

## Changes

### Domain
- ParseError(record) 추가
  - lineNumber >= 1 및 non-null 검증
  - ErrorType(PARSING/VALIDATION/FORMAT) 정의
- ParseStatistics(record) 추가
  - total/success/error 카운트 및 errorsByType, errorSamples(최대 10개) 보관
  - compact constructor에서 음수 검증 + 방어적 복사 + null 기본값 정규화
  - empty() 팩터리 제공
- InvalidCsvFormatException 추가
  - 누락 헤더 목록 포함 및 방어적 복사

- AnalysisResult 변경
  - ParseErrors 제거 → ParseStatistics parseStatistics 필드로 교체
  - null 입력 시 ParseStatistics.empty()로 기본값 보장

### Infrastructure
- CsvLogParser 개선
  - REQUIRED_HEADERS(12) 기반 헤더 검증(validateHeaders) 추가(대소문자 무시)
  - header 누락 시 InvalidCsvFormatException으로 fail-fast
  - ParseResult를 (logs, ParseStatistics)로 변경
  - 파싱 중 ParseError 샘플 및 errorsByType 집계
  - classifyError로 오류 타입 분류
  - InvalidCsvFormatException은 그대로 전파, 그 외 예외는 InvalidCsvFormatException으로 래핑

### Application
- AnalysisService 예외 처리 수정
  - InvalidCsvFormatException/IllegalArgumentException/IllegalStateException은 그대로 전파
  - 그 외만 RuntimeException으로 래핑
- ParseStatistics를 AnalysisResult에 직접 전달

### API
- AnalysisResponse
  - parseErrors → parseStatistics DTO로 교체(ParseStatisticsDto/ParseErrorDto)
  - 도메인 → DTO 변환 헬퍼 추가
- GlobalExceptionHandler
  - InvalidCsvFormatException → 400 (INVALID_CSV_FORMAT)
  - IllegalStateException → 422 (INVALID_STATE)

### Test
- 신규 테스트 추가
  - ParseErrorTest / ParseStatisticsTest / InvalidCsvFormatExceptionTest
  - CsvLogParserTest (유효/무효 헤더 검증 포함)
  - GlobalExceptionHandlerTest (HTTP 상태코드 및 errorCode 검증)
- 기존 테스트 수정
  - AnalysisResultTest: ParseStatistics 기본값 검증으로 변경
  - AnalysisResponseTest: validParseErrors → validParseStatistics

---

## Code Convention Checklist

### 1. 객체 생성 & 수명 관리
- [x] 도메인 타입은 생성 시점에 검증/정규화 규칙을 캡슐화

### 2. 불변성 & 스레드 안정성
- [x] 도메인 타입은 record + 방어적 복사로 불변성을 보장

### 3. 메서드 계약
- [x] 파서는 입력 포맷 오류를 fail-fast로 드러낸다
- [x] null 입력은 empty()/기본값으로 정규화한다
- [x] 실패 케이스는 분류 가능하도록 구조화된 오류로 남긴다

### 4. 계층 분리
- [x] 파싱/포맷 예외는 도메인 예외로 정의하고 애플리케이션에서 삼키지 않는다
- [x] API 레이어는 예외를 HTTP 응답으로 일관되게 매핑

### 5. 예외 & 로깅
- [x] 예외 메시지와 분류 정보가 사용자/운영 관점에서 해석 가능하도록 정리

---

## Behavior Change

### Before
- 잘못된 헤더 CSV도 파싱 시도 → 원인 파악이 어려운 에러 발생
- 파싱 오류 정보가 문자열 샘플 위주로 제한됨(분류/통계 불가)
- 도메인 예외가 RuntimeException으로 감싸져 API에서 올바르게 매핑되지 않음

### After
- 헤더 누락 시 즉시 InvalidCsvFormatException으로 실패(400 매핑)
- ParseStatistics로 오류 타입/라인/샘플/집계가 구조화되어 제공됨
- 도메인 예외가 전파되어 GlobalExceptionHandler에서 일관된 상태코드로 응답됨

---

## Test
```bash
./gradlew clean test
./gradlew build
```

## Risk & Rollback
- Risk: parseErrors → parseStatistics로 응답 스키마가 변경되어 API 응답을 사용하는 클라이언트가 있다면 영향 가능
- Rollback: ParseStatistics 도입 커밋과 API DTO 변경 커밋을 순서대로 롤백하면 기존 ParseErrors 구조로 복구 가능