### PR TITLE
 refactor(infra): IpInfoClient 안정성 강화 (timeout/retry/circuit breaker)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,10 +46,13 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.assertj:assertj-core:3.24.2")
     testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation("net.bytebuddy:byte-buddy:1.15.10")
+    testImplementation("net.bytebuddy:byte-buddy-agent:1.15.10")
 }
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    jvmArgs("-XX:+EnableDynamicAgentLoading")
 }
 
 tasks.withType<JavaCompile> {

--- a/src/main/java/com/electricip/loganalyzer/config/CacheConfig.java
+++ b/src/main/java/com/electricip/loganalyzer/config/CacheConfig.java
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * 캐시 설정
- * 
+ *
  * Caffeine: Spring Boot 공식 권장
  * - Window TinyLFU 알고리즘
  * - 높은 적중률 (85%)
@@ -24,13 +24,14 @@ public class CacheConfig {
     @Bean
     public CacheManager cacheManager() {
         var cacheManager = new CaffeineCacheManager();
-        
+
         cacheManager.setCaffeine(Caffeine.newBuilder()
                 .maximumSize(10_000)
-                .expireAfterWrite(1, TimeUnit.HOURS)
+                .expireAfterWrite(24, TimeUnit.HOURS)
+                .expireAfterAccess(12, TimeUnit.HOURS)
                 .initialCapacity(100)
                 .recordStats());
-        
+
         return cacheManager;
     }
 }

--- a/src/main/java/com/electricip/loganalyzer/config/WebConfig.java
+++ b/src/main/java/com/electricip/loganalyzer/config/WebConfig.java
@@ -1,7 +1,9 @@
 package com.electricip.loganalyzer.config;
 
+import com.electricip.loganalyzer.infrastructure.client.IpInfoErrorHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -9,12 +11,21 @@ import org.springframework.web.client.RestTemplate;
  */
 @Configuration
 public class WebConfig {
-    
+
     /**
      * RestTemplate Bean
+     * — 연결 타임아웃 3초, 읽기 타임아웃 5초
+     * — ipinfo API 에러 핸들러 적용
      */
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        var factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(3_000);
+        factory.setReadTimeout(5_000);
+
+        var restTemplate = new RestTemplate(factory);
+        restTemplate.setErrorHandler(new IpInfoErrorHandler());
+
+        return restTemplate;
     }
 }

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoAuthException.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoAuthException.java
@@ -1,0 +1,11 @@
+package com.electricip.loganalyzer.infrastructure.client;
+
+/**
+ * ipinfo API 인증 실패 시 발생하는 예외 (401)
+ */
+public class IpInfoAuthException extends IpInfoException {
+
+    public IpInfoAuthException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoCircuitBreaker.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoCircuitBreaker.java
@@ -1,0 +1,64 @@
+package com.electricip.loganalyzer.infrastructure.client;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * ipinfo API Circuit Breaker
+ * — 연속 실패 시 호출 차단, 타임아웃 후 half-open 복구
+ */
+@Slf4j
+@Component
+public class IpInfoCircuitBreaker {
+
+    private final AtomicInteger failureCount = new AtomicInteger(0);
+    private final AtomicLong lastFailureTime = new AtomicLong(0);
+
+    static final int FAILURE_THRESHOLD = 5;
+    static final long TIMEOUT_MS = 60_000; // 1분
+
+    /**
+     * Circuit이 열려있는지 확인
+     * — 실패 횟수가 임계치 미만이면 닫힘 (정상)
+     * — 타임아웃 이후면 half-open (재시도 허용, 카운터 리셋)
+     */
+    public boolean isOpen() {
+        if (failureCount.get() < FAILURE_THRESHOLD) {
+            return false;
+        }
+
+        // 타임아웃 지났으면 half-open → 카운터 리셋
+        if (System.currentTimeMillis() - lastFailureTime.get() > TIMEOUT_MS) {
+            log.info("Circuit Breaker half-open: 재시도 허용");
+            failureCount.set(0);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * 성공 기록 — 카운터 리셋
+     */
+    public void recordSuccess() {
+        failureCount.set(0);
+    }
+
+    /**
+     * 실패 기록 — 카운터 증가 + 시각 갱신
+     */
+    public void recordFailure() {
+        failureCount.incrementAndGet();
+        lastFailureTime.set(System.currentTimeMillis());
+    }
+
+    /**
+     * 현재 실패 횟수 (테스트용)
+     */
+    int getFailureCount() {
+        return failureCount.get();
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoClient.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoClient.java
@@ -13,24 +13,28 @@ import java.util.Objects;
 
 /**
  * ipinfo.io API 클라이언트
+ * — 타임아웃, Retry (exponential backoff), Circuit Breaker 적용
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class IpInfoClient {
-    
-    // 의존 객체 주입
+
     private final RestTemplate restTemplate;
-    
+    private final IpInfoCircuitBreaker circuitBreaker;
+
+    private static final int MAX_ATTEMPTS = 3;
+    private static final long BACKOFF_MS = 1_000;
+
     @Value("${ipinfo.base-url:https://ipinfo.io}")
     private String baseUrl;
-    
+
     @Value("${ipinfo.token:#{null}}")
     private String token;
-    
+
     /**
      * IP 정보 조회 (캐싱 적용)
-     * 
+     *
      * @param ip IP 주소
      * @return IP 정보 (null 반환하지 않음)
      * @throws NullPointerException ip가 null인 경우
@@ -38,34 +42,81 @@ public class IpInfoClient {
     @Cacheable(value = "ipInfoCache", key = "#ip", unless = "#result == null")
     public IpInfo getIpInfo(String ip) {
         Objects.requireNonNull(ip, "ip는 null일 수 없습니다");
-        
+
         if (ip.isBlank()) {
             log.warn("빈 IP 주소");
             return IpInfo.unknown(ip);
         }
-        
-        try {
-            var url = buildUrl(ip);
-            var response = restTemplate.getForObject(url, IpInfoResponse.class);
-            
-            if (response != null) {
-                log.debug("IP 정보 조회 성공: ip={}, country={}", ip, response.country);
-                
-                return IpInfo.of(
-                        response.ip,
-                        response.country,
-                        response.region,
-                        response.city,
-                        response.org
-                );
-            }
-        } catch (Exception e) {
-            log.warn("IP 정보 조회 실패: ip={}, error={}", ip, e.getMessage());
+
+        // Circuit Open → fallback
+        if (circuitBreaker.isOpen()) {
+            log.warn("Circuit Breaker open, fallback 사용: ip={}", ip);
+            return IpInfo.unknown(ip);
         }
-        
+
+        return callWithRetry(ip);
+    }
+
+    /**
+     * 재시도 로직 (exponential backoff)
+     */
+    private IpInfo callWithRetry(String ip) {
+        for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            try {
+                var result = callApi(ip);
+                circuitBreaker.recordSuccess();
+                return result;
+
+            } catch (RateLimitExceededException e) {
+                log.error("ipinfo rate limit 초과: ip={}", ip);
+                circuitBreaker.recordFailure();
+                return IpInfo.unknown(ip);
+
+            } catch (IpInfoAuthException e) {
+                log.error("ipinfo 인증 실패: ip={}", ip);
+                circuitBreaker.recordFailure();
+                return IpInfo.unknown(ip);
+
+            } catch (Exception e) {
+                circuitBreaker.recordFailure();
+
+                if (attempt == MAX_ATTEMPTS) {
+                    log.error("ipinfo API 최종 실패: ip={}, attempts={}", ip, MAX_ATTEMPTS, e);
+                    return IpInfo.unknown(ip);
+                }
+
+                log.warn("ipinfo API 재시도: ip={}, attempt={}/{}, error={}",
+                        ip, attempt, MAX_ATTEMPTS, e.getMessage());
+
+                sleep(BACKOFF_MS * attempt);
+            }
+        }
+
         return IpInfo.unknown(ip);
     }
-    
+
+    /**
+     * API 호출
+     */
+    private IpInfo callApi(String ip) {
+        var url = buildUrl(ip);
+        var response = restTemplate.getForObject(url, IpInfoResponse.class);
+
+        if (response != null) {
+            log.debug("IP 정보 조회 성공: ip={}, country={}", ip, response.country);
+
+            return IpInfo.of(
+                    response.ip,
+                    response.country,
+                    response.region,
+                    response.city,
+                    response.org
+            );
+        }
+
+        return IpInfo.unknown(ip);
+    }
+
     /**
      * API URL 구성
      */
@@ -75,7 +126,15 @@ public class IpInfoClient {
         }
         return String.format("%s/%s/json", baseUrl, ip);
     }
-    
+
+    private void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
     /**
      * ipinfo API 응답 DTO (Record)
      */

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoErrorHandler.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoErrorHandler.java
@@ -1,0 +1,36 @@
+package com.electricip.loganalyzer.infrastructure.client;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.ResponseErrorHandler;
+
+import java.io.IOException;
+
+/**
+ * ipinfo API 에러 응답 핸들러
+ * — HTTP 상태 코드별 구조화된 예외 분류
+ */
+public class IpInfoErrorHandler implements ResponseErrorHandler {
+
+    @Override
+    public boolean hasError(ClientHttpResponse response) throws IOException {
+        return response.getStatusCode().isError();
+    }
+
+    @Override
+    public void handleError(ClientHttpResponse response) throws IOException {
+        var status = response.getStatusCode();
+
+        if (status == HttpStatus.TOO_MANY_REQUESTS) {
+            throw new RateLimitExceededException("ipinfo API rate limit 초과");
+        }
+        if (status == HttpStatus.UNAUTHORIZED || status == HttpStatus.FORBIDDEN) {
+            throw new IpInfoAuthException("ipinfo API 인증 실패");
+        }
+        if (status.is5xxServerError()) {
+            throw new IpInfoServerException("ipinfo 서버 오류: " + status.value());
+        }
+
+        throw new IpInfoException("ipinfo API 오류: " + status.value());
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoException.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoException.java
@@ -1,0 +1,15 @@
+package com.electricip.loganalyzer.infrastructure.client;
+
+/**
+ * ipinfo API 호출 시 발생하는 기본 예외
+ */
+public class IpInfoException extends RuntimeException {
+
+    public IpInfoException(String message) {
+        super(message);
+    }
+
+    public IpInfoException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoServerException.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoServerException.java
@@ -1,0 +1,11 @@
+package com.electricip.loganalyzer.infrastructure.client;
+
+/**
+ * ipinfo 서버 오류 시 발생하는 예외 (5xx)
+ */
+public class IpInfoServerException extends IpInfoException {
+
+    public IpInfoServerException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/client/RateLimitExceededException.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/client/RateLimitExceededException.java
@@ -1,0 +1,11 @@
+package com.electricip.loganalyzer.infrastructure.client;
+
+/**
+ * ipinfo API rate limit 초과 시 발생하는 예외 (429)
+ */
+public class RateLimitExceededException extends IpInfoException {
+
+    public RateLimitExceededException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/com/electricip/loganalyzer/infrastructure/client/IpInfoCircuitBreakerTest.java
+++ b/src/test/java/com/electricip/loganalyzer/infrastructure/client/IpInfoCircuitBreakerTest.java
@@ -1,0 +1,110 @@
+package com.electricip.loganalyzer.infrastructure.client;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IpInfoCircuitBreakerTest {
+
+    private IpInfoCircuitBreaker circuitBreaker;
+
+    @BeforeEach
+    void setUp() {
+        circuitBreaker = new IpInfoCircuitBreaker();
+    }
+
+    @Nested
+    @DisplayName("Closed 상태 (정상)")
+    class ClosedStateTest {
+
+        @Test
+        @DisplayName("초기 상태에서 circuit은 닫혀있다")
+        void shouldBeClosedInitially() {
+            assertThat(circuitBreaker.isOpen()).isFalse();
+        }
+
+        @Test
+        @DisplayName("임계치 미만 실패 시 circuit은 닫혀있다")
+        void shouldRemainClosedBelowThreshold() {
+            for (int i = 0; i < IpInfoCircuitBreaker.FAILURE_THRESHOLD - 1; i++) {
+                circuitBreaker.recordFailure();
+            }
+
+            assertThat(circuitBreaker.isOpen()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("Open 상태 (차단)")
+    class OpenStateTest {
+
+        @Test
+        @DisplayName("임계치 도달 시 circuit이 열린다")
+        void shouldOpenAtThreshold() {
+            for (int i = 0; i < IpInfoCircuitBreaker.FAILURE_THRESHOLD; i++) {
+                circuitBreaker.recordFailure();
+            }
+
+            assertThat(circuitBreaker.isOpen()).isTrue();
+        }
+
+        @Test
+        @DisplayName("임계치 초과 실패 시에도 circuit은 열려있다")
+        void shouldRemainOpenAboveThreshold() {
+            for (int i = 0; i < IpInfoCircuitBreaker.FAILURE_THRESHOLD + 5; i++) {
+                circuitBreaker.recordFailure();
+            }
+
+            assertThat(circuitBreaker.isOpen()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("복구 동작")
+    class RecoveryTest {
+
+        @Test
+        @DisplayName("성공 기록 시 카운터가 리셋된다")
+        void shouldResetOnSuccess() {
+            for (int i = 0; i < IpInfoCircuitBreaker.FAILURE_THRESHOLD; i++) {
+                circuitBreaker.recordFailure();
+            }
+            assertThat(circuitBreaker.isOpen()).isTrue();
+
+            circuitBreaker.recordSuccess();
+
+            assertThat(circuitBreaker.isOpen()).isFalse();
+            assertThat(circuitBreaker.getFailureCount()).isZero();
+        }
+
+        @Test
+        @DisplayName("실패 후 성공하면 카운터가 리셋된다")
+        void shouldResetCounterAfterSuccess() {
+            circuitBreaker.recordFailure();
+            circuitBreaker.recordFailure();
+            circuitBreaker.recordSuccess();
+
+            assertThat(circuitBreaker.getFailureCount()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("상수값 검증")
+    class ConstantsTest {
+
+        @Test
+        @DisplayName("FAILURE_THRESHOLD는 5이다")
+        void shouldHaveFailureThresholdOf5() {
+            assertThat(IpInfoCircuitBreaker.FAILURE_THRESHOLD).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("TIMEOUT_MS는 60초이다")
+        void shouldHaveTimeoutOf60Seconds() {
+            assertThat(IpInfoCircuitBreaker.TIMEOUT_MS).isEqualTo(60_000);
+        }
+    }
+}

--- a/src/test/java/com/electricip/loganalyzer/infrastructure/client/IpInfoClientTest.java
+++ b/src/test/java/com/electricip/loganalyzer/infrastructure/client/IpInfoClientTest.java
@@ -1,0 +1,157 @@
+package com.electricip.loganalyzer.infrastructure.client;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class IpInfoClientTest {
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    private IpInfoCircuitBreaker circuitBreaker;
+    private IpInfoClient client;
+
+    @BeforeEach
+    void setUp() {
+        circuitBreaker = new IpInfoCircuitBreaker();
+        client = new IpInfoClient(restTemplate, circuitBreaker);
+        ReflectionTestUtils.setField(client, "baseUrl", "https://ipinfo.io");
+        ReflectionTestUtils.setField(client, "token", null);
+    }
+
+    @Nested
+    @DisplayName("정상 호출")
+    class SuccessTest {
+
+        @Test
+        @DisplayName("null IP는 NullPointerException 발생")
+        void shouldThrowForNullIp() {
+            assertThatThrownBy(() -> client.getIpInfo(null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("빈 IP는 IllegalArgumentException 발생")
+        void shouldThrowForBlankIp() {
+            assertThatThrownBy(() -> client.getIpInfo("  "))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("Circuit Breaker 통합")
+    class CircuitBreakerTest {
+
+        @Test
+        @DisplayName("Circuit Open 시 API 호출 없이 fallback 반환")
+        void shouldReturnFallbackWhenCircuitOpen() {
+            // Circuit을 열기
+            for (int i = 0; i < IpInfoCircuitBreaker.FAILURE_THRESHOLD; i++) {
+                circuitBreaker.recordFailure();
+            }
+
+            var result = client.getIpInfo("1.2.3.4");
+
+            assertThat(result).isNotNull();
+            assertThat(result.isValid()).isFalse();
+            // RestTemplate은 호출되지 않아야 함
+            verifyNoInteractions(restTemplate);
+        }
+
+        @Test
+        @DisplayName("API 실패 시 Circuit Breaker에 실패가 기록된다")
+        void shouldRecordFailureOnApiError() {
+            when(restTemplate.getForObject(anyString(), any(Class.class)))
+                    .thenThrow(new IpInfoServerException("서버 오류"));
+
+            client.getIpInfo("1.2.3.4");
+
+            // MAX_ATTEMPTS(3)만큼 실패 기록
+            assertThat(circuitBreaker.getFailureCount()).isEqualTo(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("Retry 동작")
+    class RetryTest {
+
+        @Test
+        @DisplayName("RateLimitExceededException은 재시도하지 않는다")
+        void shouldNotRetryOnRateLimit() {
+            when(restTemplate.getForObject(anyString(), any(Class.class)))
+                    .thenThrow(new RateLimitExceededException("rate limit"));
+
+            var result = client.getIpInfo("1.2.3.4");
+
+            assertThat(result.isValid()).isFalse();
+            // 1번만 호출 (재시도 없음)
+            verify(restTemplate, times(1)).getForObject(anyString(), any(Class.class));
+        }
+
+        @Test
+        @DisplayName("IpInfoAuthException은 재시도하지 않는다")
+        void shouldNotRetryOnAuthError() {
+            when(restTemplate.getForObject(anyString(), any(Class.class)))
+                    .thenThrow(new IpInfoAuthException("auth failed"));
+
+            var result = client.getIpInfo("1.2.3.4");
+
+            assertThat(result.isValid()).isFalse();
+            // 1번만 호출 (재시도 없음)
+            verify(restTemplate, times(1)).getForObject(anyString(), any(Class.class));
+        }
+
+        @Test
+        @DisplayName("일반 예외는 MAX_ATTEMPTS까지 재시도한다")
+        void shouldRetryOnGeneralException() {
+            when(restTemplate.getForObject(anyString(), any(Class.class)))
+                    .thenThrow(new IpInfoServerException("서버 오류"));
+
+            var result = client.getIpInfo("1.2.3.4");
+
+            assertThat(result.isValid()).isFalse();
+            // 3번 호출 (최초 + 2회 재시도)
+            verify(restTemplate, times(3)).getForObject(anyString(), any(Class.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("에러 타입 분류")
+    class ErrorClassificationTest {
+
+        @Test
+        @DisplayName("RateLimitExceededException은 IpInfoException의 하위 타입이다")
+        void rateLimitShouldExtendIpInfoException() {
+            var ex = new RateLimitExceededException("test");
+            assertThat(ex).isInstanceOf(IpInfoException.class);
+        }
+
+        @Test
+        @DisplayName("IpInfoAuthException은 IpInfoException의 하위 타입이다")
+        void authShouldExtendIpInfoException() {
+            var ex = new IpInfoAuthException("test");
+            assertThat(ex).isInstanceOf(IpInfoException.class);
+        }
+
+        @Test
+        @DisplayName("IpInfoServerException은 IpInfoException의 하위 타입이다")
+        void serverShouldExtendIpInfoException() {
+            var ex = new IpInfoServerException("test");
+            assertThat(ex).isInstanceOf(IpInfoException.class);
+        }
+    }
+}

--- a/src/test/java/com/electricip/loganalyzer/infrastructure/client/IpInfoErrorHandlerTest.java
+++ b/src/test/java/com/electricip/loganalyzer/infrastructure/client/IpInfoErrorHandlerTest.java
@@ -1,0 +1,115 @@
+package com.electricip.loganalyzer.infrastructure.client;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.client.MockClientHttpResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class IpInfoErrorHandlerTest {
+
+    private IpInfoErrorHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new IpInfoErrorHandler();
+    }
+
+    @Nested
+    @DisplayName("hasError 검증")
+    class HasErrorTest {
+
+        @Test
+        @DisplayName("2xx 응답은 에러가 아니다")
+        void shouldNotHaveErrorFor2xx() throws Exception {
+            try (var response = new MockClientHttpResponse(new byte[0], HttpStatus.OK)) {
+                assertThat(handler.hasError(response)).isFalse();
+            }
+        }
+
+        @Test
+        @DisplayName("4xx 응답은 에러이다")
+        void shouldHaveErrorFor4xx() throws Exception {
+            try (var response = new MockClientHttpResponse(new byte[0], HttpStatus.BAD_REQUEST)) {
+                assertThat(handler.hasError(response)).isTrue();
+            }
+        }
+
+        @Test
+        @DisplayName("5xx 응답은 에러이다")
+        void shouldHaveErrorFor5xx() throws Exception {
+            try (var response = new MockClientHttpResponse(new byte[0], HttpStatus.INTERNAL_SERVER_ERROR)) {
+                assertThat(handler.hasError(response)).isTrue();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("handleError 검증")
+    class HandleErrorTest {
+
+        @Test
+        @DisplayName("429는 RateLimitExceededException 발생")
+        void shouldThrowRateLimitExceptionFor429() {
+            try (var response = new MockClientHttpResponse(new byte[0], HttpStatus.TOO_MANY_REQUESTS)) {
+                assertThatThrownBy(() -> handler.handleError(response))
+                        .isInstanceOf(RateLimitExceededException.class)
+                        .hasMessageContaining("rate limit");
+            }
+        }
+
+        @Test
+        @DisplayName("401은 IpInfoAuthException 발생")
+        void shouldThrowAuthExceptionFor401() {
+            try (var response = new MockClientHttpResponse(new byte[0], HttpStatus.UNAUTHORIZED)) {
+                assertThatThrownBy(() -> handler.handleError(response))
+                        .isInstanceOf(IpInfoAuthException.class)
+                        .hasMessageContaining("인증");
+            }
+        }
+
+        @Test
+        @DisplayName("403은 IpInfoAuthException 발생")
+        void shouldThrowAuthExceptionFor403() {
+            try (var response = new MockClientHttpResponse(new byte[0], HttpStatus.FORBIDDEN)) {
+                assertThatThrownBy(() -> handler.handleError(response))
+                        .isInstanceOf(IpInfoAuthException.class)
+                        .hasMessageContaining("인증");
+            }
+        }
+
+        @Test
+        @DisplayName("500은 IpInfoServerException 발생")
+        void shouldThrowServerExceptionFor500() {
+            try (var response = new MockClientHttpResponse(new byte[0], HttpStatus.INTERNAL_SERVER_ERROR)) {
+                assertThatThrownBy(() -> handler.handleError(response))
+                        .isInstanceOf(IpInfoServerException.class)
+                        .hasMessageContaining("서버 오류");
+            }
+        }
+
+        @Test
+        @DisplayName("503은 IpInfoServerException 발생")
+        void shouldThrowServerExceptionFor503() {
+            try (var response = new MockClientHttpResponse(new byte[0], HttpStatus.SERVICE_UNAVAILABLE)) {
+                assertThatThrownBy(() -> handler.handleError(response))
+                        .isInstanceOf(IpInfoServerException.class)
+                        .hasMessageContaining("서버 오류");
+            }
+        }
+
+        @Test
+        @DisplayName("404는 일반 IpInfoException 발생")
+        void shouldThrowIpInfoExceptionForOtherErrors() {
+            try (var response = new MockClientHttpResponse(new byte[0], HttpStatus.NOT_FOUND)) {
+                assertThatThrownBy(() -> handler.handleError(response))
+                        .isInstanceOf(IpInfoException.class)
+                        .hasMessageContaining("404");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
IpInfo 외부 API 연동의 안정성을 개선하기 위해
타임아웃, 재시도, Circuit Breaker, 오류 분류 및 캐시 정책을 적용

---

## Context

### Issue #11 
- Issue : #11 
- IpInfo API 호출에 타임아웃이 없어 외부 서버 지연 시 스레드가 무한 대기할 수 있었음
- 일시적인 네트워크 오류도 재시도 없이 즉시 실패 처리됨
- API 장애 상황에서도 호출이 계속 발생해 불필요한 부하 유발
- 401 / 429 / 5xx / 네트워크 오류가 모두 동일하게 처리되어
  오류 원인에 따른 대응이 불가능했음
- 캐시 TTL이 짧아 불필요한 외부 호출 빈도가 높았음

### Background
- 외부 API 연동은 **서비스 전체 안정성에 직접적인 영향을 주는 지점**이므로
  실패를 빠르게 감지하고, 회복 가능성에 따라 대응을 달리해야 함
- Spring Retry / Resilience4j 도입도 고려했으나,
  현재 스코프에서는 **의존성 최소화 + 명시적인 제어**를 우선함
- 이에 따라 타임아웃, Retry, Circuit Breaker를 직접 구현하고
  HTTP 상태 코드 기반 오류 분류를 적용함

---

## Changes

### Infrastructure
- **RestTemplate 설정**
  - connect timeout 3s / read timeout 5s 적용
  - IpInfoErrorHandler 등록

- **오류 분류 및 예외 구조화**
  - `IpInfoException` (base)
  - `RateLimitExceededException` (429, retry ❌)
  - `IpInfoAuthException` (401/403, retry ❌)
  - `IpInfoServerException` (5xx, retry ⭕)
  - `IpInfoErrorHandler`에서 HTTP 상태 코드 기반 예외 분류

- **Retry 로직 추가**
  - 최대 3회 재시도
  - exponential backoff 적용
  - RateLimit / Auth 오류는 즉시 중단
  - 최종 실패 시 fallback(`IpInfo.unknown()`)

- **Circuit Breaker 도입**
  - 실패 임계치: 5회
  - open timeout: 60초
  - half-open 상태에서 자동 복구 시도
  - thread-safe(Atomic 기반) 구현

- **캐시 정책 개선**
  - expireAfterWrite: 1h → 24h
  - expireAfterAccess: 12h 추가
  - 불필요한 외부 호출 감소

### Config
- `WebConfig`
  - RestTemplate timeout 및 error handler 설정
- `CacheConfig`
  - Caffeine TTL 정책 조정

### Test
- `IpInfoCircuitBreakerTest`
  - closed / open / recovery 상태 검증
- `IpInfoErrorHandlerTest`
  - 401 / 403 / 429 / 5xx / 기타 4xx 분류 검증
- `IpInfoClientTest`
  - null/blank 입력
  - error type별 retry 여부
  - circuit open 시 fallback 동작
  - retry 횟수 검증

---

## Code Convention Checklist

### 1. 객체 생성 & 수명 관리
- [x] 외부 리소스 호출은 실패를 빠르게 감지하도록 타임아웃을 설정

### 2. 불변성 & 스레드 안정성
- [x] Circuit Breaker는 thread-safe 하게 구현

### 3. 메서드 계약
- [x] 오류 타입에 따라 재시도/중단 정책을 명확히 분리
- [x] 실패 시 fallback 동작이 보장

### 4. 계층 분리
- [x] 외부 API 오류는 infrastructure 계층에서 분류/처리
- [x] 도메인 및 상위 계층은 IpInfo 추상 결과만 의존

### 5. 예외 & 로깅
- [x] 오류 유형별로 로그 레벨 및 메시지를 구분
- [x] 장애 상황에서도 로그 폭증을 방지

---

## Behavior Change

### Before
- IpInfo API 지연 시 스레드 무한 대기 가능
- 일시적 오류도 즉시 실패
- 장애 상황에서도 반복 호출 발생
- 오류 원인 구분 불가

### After
- 최악의 경우 5초 내 응답 보장
- 일시적 오류는 재시도로 복구 시도
- 장애 시 Circuit Breaker로 호출 차단
- 오류 타입별로 명확한 처리 전략 적용

---

## Test
```bash
./gradlew test
./gradlew build
```

## Risk & Rollback
- Risk: retry/backoff로 인해 단일 요청 지연 시간이 증가할 수 있음
- Rollback: IpInfoClient 및 관련 infra 변경 커밋을 롤백하면 기존 단순 호출 방식으로 복구 가능