### PR TITLE
refactor: LogAnalyzerException 기반 예외 계층 통합 및 API 에러 매핑 정리

### DIFF
--- a/src/main/java/com/electricip/loganalyzer/api/AnalysisController.java
+++ b/src/main/java/com/electricip/loganalyzer/api/AnalysisController.java
@@ -1,11 +1,19 @@
 package com.electricip.loganalyzer.api;
 
+import com.electricip.loganalyzer.api.GlobalExceptionHandler.ErrorResponse;
 import com.electricip.loganalyzer.application.AnalysisService;
+import com.electricip.loganalyzer.domain.exception.AnalysisNotFoundException;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -30,9 +38,22 @@ public class AnalysisController {
     /**
      * 로그 파일 분석
      */
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "로그 파일 분석", description = "CSV 로그 파일을 업로드하여 분석합니다")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "분석 성공",
+                    content = @Content(schema = @Schema(implementation = AnalysisIdResponse.class))),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 파일 또는 CSV 형식 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "413", description = "파일 크기 초과",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "422", description = "파싱 에러 과다 (유효한 로그 없음)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     public ResponseEntity<AnalysisIdResponse> analyze(
+            @Parameter(description = "분석할 CSV 로그 파일", required = true)
             @RequestParam("file") @NotNull(message = "파일은 필수입니다") MultipartFile file) {
         
         log.info("분석 요청: file={}", file.getOriginalFilename());
@@ -50,14 +71,22 @@ public class AnalysisController {
      */
     @GetMapping("/{analysisId}")
     @Operation(summary = "분석 결과 조회", description = "분석 ID로 결과를 조회합니다")
-    public ResponseEntity<AnalysisResponse> getResult(@PathVariable String analysisId) {
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = AnalysisResponse.class))),
+            @ApiResponse(responseCode = "404", description = "분석 결과를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<AnalysisResponse> getResult(
+            @Parameter(description = "분석 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+            @PathVariable String analysisId) {
 
         Objects.requireNonNull(analysisId, "analysisId는 null일 수 없습니다");
-        
-        return analysisService.getById(analysisId)
-                .map(AnalysisResponse::from)
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+
+        var result = analysisService.getById(analysisId)
+                .orElseThrow(() -> new AnalysisNotFoundException(analysisId));
+
+        return ResponseEntity.ok(AnalysisResponse.from(result));
     }
     
     /**
@@ -65,6 +94,7 @@ public class AnalysisController {
      */
     @GetMapping
     @Operation(summary = "전체 결과 조회", description = "모든 분석 결과를 조회합니다")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
     public ResponseEntity<List<AnalysisResponse>> getAllResults() {
         
         var results = analysisService.getAll().stream()
@@ -79,7 +109,13 @@ public class AnalysisController {
      */
     @DeleteMapping("/{analysisId}")
     @Operation(summary = "결과 삭제", description = "분석 결과를 삭제합니다")
-    public ResponseEntity<Void> deleteResult(@PathVariable String analysisId) {
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "분석 결과를 찾을 수 없음")
+    })
+    public ResponseEntity<Void> deleteResult(
+            @Parameter(description = "분석 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+            @PathVariable String analysisId) {
         
         Objects.requireNonNull(analysisId, "analysisId는 null일 수 없습니다");
         
@@ -90,7 +126,12 @@ public class AnalysisController {
     /**
      * 분석 ID 응답 (Record)
      */
-    public record AnalysisIdResponse(String analysisId, String message) {
+    @Schema(description = "분석 완료 응답")
+    public record AnalysisIdResponse(
+            @Schema(description = "분석 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+            String analysisId,
+            @Schema(description = "결과 메시지", example = "분석이 완료되었습니다")
+            String message) {
 
         public AnalysisIdResponse {
             Objects.requireNonNull(analysisId, "analysisId는 null일 수 없습니다");

--- a/src/main/java/com/electricip/loganalyzer/api/AnalysisResponse.java
+++ b/src/main/java/com/electricip/loganalyzer/api/AnalysisResponse.java
@@ -3,6 +3,7 @@ package com.electricip.loganalyzer.api;
 import com.electricip.loganalyzer.domain.AnalysisResult;
 import com.electricip.loganalyzer.domain.ParseError;
 import com.electricip.loganalyzer.domain.ParseStatistics;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.NonNull;
 
@@ -15,10 +16,14 @@ import java.util.Objects;
 /**
  * 분석 결과 응답 DTO
  */
+@Schema(description = "분석 결과 응답")
 @Builder
 public record AnalysisResponse(
+        @Schema(description = "분석 ID", example = "550e8400-e29b-41d4-a716-446655440000")
         @NonNull String analysisId,
+        @Schema(description = "분석 완료 시각", example = "2026-02-09T14:30:00")
         @NonNull LocalDateTime completedAt,
+        @Schema(description = "처리 소요 시간 (ms)", example = "1250")
         Long processingTimeMs,
         @NonNull BasicStats basicStats,
         @NonNull TopStats topStats,
@@ -127,20 +132,34 @@ public record AnalysisResponse(
 
     // 내부 Record들
 
+    @Schema(description = "기본 통계")
     public record BasicStats(
+            @Schema(description = "전체 요청 수", example = "15000")
             long totalRequests,
+            @Schema(description = "성공 요청 수 (2xx)", example = "12000")
             long successCount,
+            @Schema(description = "리다이렉트 수 (3xx)", example = "500")
             long redirectCount,
+            @Schema(description = "클라이언트 에러 수 (4xx)", example = "2000")
             long clientErrorCount,
+            @Schema(description = "서버 에러 수 (5xx)", example = "500")
             long serverErrorCount,
+            @Schema(description = "성공률 (%)", example = "80.0")
             double successRate,
+            @Schema(description = "리다이렉트율 (%)", example = "3.33")
             double redirectRate,
+            @Schema(description = "클라이언트 에러율 (%)", example = "13.33")
             double clientErrorRate,
+            @Schema(description = "서버 에러율 (%)", example = "3.33")
             double serverErrorRate) {}
 
+    @Schema(description = "상위 항목 통계")
     public record TopStats(
+            @Schema(description = "상위 요청 경로")
             List<PathStat> topPaths,
+            @Schema(description = "상위 상태 코드")
             List<StatusCodeStat> topStatusCodes,
+            @Schema(description = "상위 IP")
             List<IpStat> topIps) {
 
         public TopStats {
@@ -150,22 +169,51 @@ public record AnalysisResponse(
         }
     }
 
-    public record PathStat(String path, long count) {}
-    public record StatusCodeStat(String statusCode, long count) {}
-    public record IpStat(String ip, long count) {}
+    @Schema(description = "경로별 요청 통계")
+    public record PathStat(
+            @Schema(description = "요청 경로", example = "/api/users")
+            String path,
+            @Schema(description = "요청 횟수", example = "3500")
+            long count) {}
 
-    public record IpDetail(
+    @Schema(description = "상태 코드별 통계")
+    public record StatusCodeStat(
+            @Schema(description = "HTTP 상태 코드", example = "200")
+            String statusCode,
+            @Schema(description = "발생 횟수", example = "12000")
+            long count) {}
+
+    @Schema(description = "IP별 요청 통계")
+    public record IpStat(
+            @Schema(description = "클라이언트 IP", example = "192.168.1.100")
             String ip,
+            @Schema(description = "요청 횟수", example = "850")
+            long count) {}
+
+    @Schema(description = "IP 상세 정보")
+    public record IpDetail(
+            @Schema(description = "IP 주소", example = "8.8.8.8")
+            String ip,
+            @Schema(description = "국가", example = "US")
             String country,
+            @Schema(description = "지역", example = "California")
             String region,
+            @Schema(description = "도시", example = "Mountain View")
             String city,
+            @Schema(description = "조직/ISP", example = "Google LLC")
             String organization) {}
 
+    @Schema(description = "파싱 통계")
     public record ParseStatisticsDto(
+            @Schema(description = "전체 라인 수", example = "15200")
             long totalLines,
+            @Schema(description = "파싱 성공 수", example = "15000")
             long successCount,
+            @Schema(description = "파싱 에러 수", example = "200")
             long errorCount,
+            @Schema(description = "에러 유형별 카운트")
             Map<String, Integer> errorsByType,
+            @Schema(description = "에러 샘플 목록")
             List<ParseErrorDto> errorSamples) {
 
         public ParseStatisticsDto {
@@ -174,16 +222,26 @@ public record AnalysisResponse(
         }
     }
 
+    @Schema(description = "파싱 에러 상세")
     public record ParseErrorDto(
+            @Schema(description = "에러 발생 라인 번호", example = "42")
             long lineNumber,
+            @Schema(description = "에러 메시지", example = "잘못된 날짜 형식")
             String errorMessage,
+            @Schema(description = "에러 유형", example = "PARSING")
             String errorType,
+            @Schema(description = "에러 발생 시각", example = "2026-02-09T14:30:00")
             LocalDateTime occurredAt) {}
 
+    @Schema(description = "추가 통계")
     public record AdditionalStats(
+            @Schema(description = "HTTP 메서드별 요청 수")
             Map<String, Long> methodStats,
+            @Schema(description = "평균 응답 시간 (ms)", example = "125.5")
             double avgResponseTime,
+            @Schema(description = "평균 전송 바이트", example = "2048.0")
             double avgSentBytes,
+            @Schema(description = "총 트래픽 (bytes)", example = "30720000")
             long totalTraffic) {
 
         public AdditionalStats {

--- a/src/main/java/com/electricip/loganalyzer/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/electricip/loganalyzer/api/GlobalExceptionHandler.java
@@ -1,6 +1,16 @@
 package com.electricip.loganalyzer.api;
 
 import com.electricip.loganalyzer.domain.InvalidCsvFormatException;
+import com.electricip.loganalyzer.domain.exception.AnalysisNotFoundException;
+import com.electricip.loganalyzer.domain.exception.DuplicateAnalysisIdException;
+import com.electricip.loganalyzer.domain.exception.FileTooLargeException;
+import com.electricip.loganalyzer.domain.exception.InvalidFileException;
+import com.electricip.loganalyzer.domain.exception.LogAnalyzerException;
+import com.electricip.loganalyzer.domain.exception.LogParsingException;
+import com.electricip.loganalyzer.domain.exception.TooManyParsingErrorsException;
+import com.electricip.loganalyzer.infrastructure.client.IpInfoException;
+import com.electricip.loganalyzer.infrastructure.client.RateLimitExceededException;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -17,66 +27,9 @@ import java.time.LocalDateTime;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-    
+
     /**
-     * IllegalArgumentException 처리
-     */
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ErrorResponse> handleIllegalArgument(
-            IllegalArgumentException e, HttpServletRequest request) {
-        
-        log.error("잘못된 요청: {}", e.getMessage());
-        
-        return ResponseEntity
-                .badRequest()
-                .body(ErrorResponse.of(
-                        HttpStatus.BAD_REQUEST,
-                        "INVALID_REQUEST",
-                        e.getMessage(),
-                        request.getRequestURI()
-                ));
-    }
-    
-    /**
-     * NullPointerException 처리
-     */
-    @ExceptionHandler(NullPointerException.class)
-    public ResponseEntity<ErrorResponse> handleNullPointer(
-            NullPointerException e, HttpServletRequest request) {
-        
-        log.error("Null 참조: {}", e.getMessage());
-        
-        return ResponseEntity
-                .badRequest()
-                .body(ErrorResponse.of(
-                        HttpStatus.BAD_REQUEST,
-                        "NULL_REFERENCE",
-                        e.getMessage(),
-                        request.getRequestURI()
-                ));
-    }
-    
-    /**
-     * 파일 크기 초과
-     */
-    @ExceptionHandler(MaxUploadSizeExceededException.class)
-    public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceeded(
-            MaxUploadSizeExceededException e, HttpServletRequest request) {
-        
-        log.error("파일 크기 초과");
-        
-        return ResponseEntity
-                .status(HttpStatus.PAYLOAD_TOO_LARGE)
-                .body(ErrorResponse.of(
-                        HttpStatus.PAYLOAD_TOO_LARGE,
-                        "FILE_TOO_LARGE",
-                        "파일 크기 초과 (최대 50MB)",
-                        request.getRequestURI()
-                ));
-    }
-    
-    /**
-     * InvalidCsvFormatException 처리
+     * InvalidCsvFormatException 처리 → 400
      */
     @ExceptionHandler(InvalidCsvFormatException.class)
     public ResponseEntity<ErrorResponse> handleInvalidCsvFormat(
@@ -88,27 +41,198 @@ public class GlobalExceptionHandler {
                 .badRequest()
                 .body(ErrorResponse.of(
                         HttpStatus.BAD_REQUEST,
-                        "INVALID_CSV_FORMAT",
+                        e.getErrorCode(),
                         e.getMessage(),
                         request.getRequestURI()
                 ));
     }
 
     /**
-     * IllegalStateException 처리
+     * FileTooLargeException 처리 → 413
      */
-    @ExceptionHandler(IllegalStateException.class)
-    public ResponseEntity<ErrorResponse> handleIllegalState(
-            IllegalStateException e, HttpServletRequest request) {
+    @ExceptionHandler(FileTooLargeException.class)
+    public ResponseEntity<ErrorResponse> handleFileTooLarge(
+            FileTooLargeException e, HttpServletRequest request) {
 
-        log.error("잘못된 상태: {}", e.getMessage());
+        log.error("파일 크기 초과: {}", e.getMessage());
+
+        return ResponseEntity
+                .status(HttpStatus.PAYLOAD_TOO_LARGE)
+                .body(ErrorResponse.of(
+                        HttpStatus.PAYLOAD_TOO_LARGE,
+                        e.getErrorCode(),
+                        e.getMessage(),
+                        request.getRequestURI()
+                ));
+    }
+
+    /**
+     * InvalidFileException 처리 → 400
+     */
+    @ExceptionHandler(InvalidFileException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidFile(
+            InvalidFileException e, HttpServletRequest request) {
+
+        log.error("유효하지 않은 파일: {}", e.getMessage());
+
+        return ResponseEntity
+                .badRequest()
+                .body(ErrorResponse.of(
+                        HttpStatus.BAD_REQUEST,
+                        e.getErrorCode(),
+                        e.getMessage(),
+                        request.getRequestURI()
+                ));
+    }
+
+    /**
+     * LogParsingException 처리 → 400
+     */
+    @ExceptionHandler(LogParsingException.class)
+    public ResponseEntity<ErrorResponse> handleLogParsing(
+            LogParsingException e, HttpServletRequest request) {
+
+        log.error("로그 파싱 오류: {}", e.getMessage());
+
+        return ResponseEntity
+                .badRequest()
+                .body(ErrorResponse.of(
+                        HttpStatus.BAD_REQUEST,
+                        e.getErrorCode(),
+                        e.getMessage(),
+                        request.getRequestURI()
+                ));
+    }
+
+    /**
+     * TooManyParsingErrorsException 처리 → 422
+     */
+    @ExceptionHandler(TooManyParsingErrorsException.class)
+    public ResponseEntity<ErrorResponse> handleTooManyParsingErrors(
+            TooManyParsingErrorsException e, HttpServletRequest request) {
+
+        log.error("파싱 에러 과다: {}", e.getMessage());
 
         return ResponseEntity
                 .status(HttpStatus.UNPROCESSABLE_ENTITY)
                 .body(ErrorResponse.of(
                         HttpStatus.UNPROCESSABLE_ENTITY,
-                        "INVALID_STATE",
+                        e.getErrorCode(),
                         e.getMessage(),
+                        request.getRequestURI()
+                ));
+    }
+
+    /**
+     * AnalysisNotFoundException 처리 → 404
+     */
+    @ExceptionHandler(AnalysisNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleAnalysisNotFound(
+            AnalysisNotFoundException e, HttpServletRequest request) {
+
+        log.error("분석 결과 미발견: {}", e.getMessage());
+
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(ErrorResponse.of(
+                        HttpStatus.NOT_FOUND,
+                        e.getErrorCode(),
+                        e.getMessage(),
+                        request.getRequestURI()
+                ));
+    }
+
+    /**
+     * DuplicateAnalysisIdException 처리 → 409
+     */
+    @ExceptionHandler(DuplicateAnalysisIdException.class)
+    public ResponseEntity<ErrorResponse> handleDuplicateAnalysisId(
+            DuplicateAnalysisIdException e, HttpServletRequest request) {
+
+        log.error("중복 분석 ID: {}", e.getMessage());
+
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(ErrorResponse.of(
+                        HttpStatus.CONFLICT,
+                        e.getErrorCode(),
+                        e.getMessage(),
+                        request.getRequestURI()
+                ));
+    }
+
+    /**
+     * RateLimitExceededException 처리 → 429
+     */
+    @ExceptionHandler(RateLimitExceededException.class)
+    public ResponseEntity<ErrorResponse> handleRateLimitExceeded(
+            RateLimitExceededException e, HttpServletRequest request) {
+
+        log.error("API rate limit 초과: {}", e.getMessage());
+
+        return ResponseEntity
+                .status(HttpStatus.TOO_MANY_REQUESTS)
+                .body(ErrorResponse.of(
+                        HttpStatus.TOO_MANY_REQUESTS,
+                        e.getErrorCode(),
+                        e.getMessage(),
+                        request.getRequestURI()
+                ));
+    }
+
+    /**
+     * IpInfoException (나머지) 처리 → 502
+     */
+    @ExceptionHandler(IpInfoException.class)
+    public ResponseEntity<ErrorResponse> handleIpInfoException(
+            IpInfoException e, HttpServletRequest request) {
+
+        log.error("IP 정보 조회 오류: {}", e.getMessage());
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_GATEWAY)
+                .body(ErrorResponse.of(
+                        HttpStatus.BAD_GATEWAY,
+                        e.getErrorCode(),
+                        e.getMessage(),
+                        request.getRequestURI()
+                ));
+    }
+
+    /**
+     * LogAnalyzerException catch-all → 500
+     */
+    @ExceptionHandler(LogAnalyzerException.class)
+    public ResponseEntity<ErrorResponse> handleLogAnalyzerException(
+            LogAnalyzerException e, HttpServletRequest request) {
+
+        log.error("애플리케이션 오류: {}", e.getMessage(), e);
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ErrorResponse.of(
+                        HttpStatus.INTERNAL_SERVER_ERROR,
+                        e.getErrorCode(),
+                        e.getMessage(),
+                        request.getRequestURI()
+                ));
+    }
+
+    /**
+     * 파일 크기 초과 (Spring)
+     */
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceeded(
+            MaxUploadSizeExceededException e, HttpServletRequest request) {
+
+        log.error("파일 크기 초과");
+
+        return ResponseEntity
+                .status(HttpStatus.PAYLOAD_TOO_LARGE)
+                .body(ErrorResponse.of(
+                        HttpStatus.PAYLOAD_TOO_LARGE,
+                        "FILE_TOO_LARGE",
+                        "파일 크기 초과 (최대 50MB)",
                         request.getRequestURI()
                 ));
     }
@@ -119,9 +243,9 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(
             Exception e, HttpServletRequest request) {
-        
+
         log.error("서버 오류: {}", e.getMessage(), e);
-        
+
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ErrorResponse.of(
@@ -131,15 +255,21 @@ public class GlobalExceptionHandler {
                         request.getRequestURI()
                 ));
     }
-    
+
     /**
      * 에러 응답 (Record)
      */
+    @Schema(description = "에러 응답")
     public record ErrorResponse(
+            @Schema(description = "에러 발생 시각", example = "2026-02-09T14:30:00")
             LocalDateTime timestamp,
+            @Schema(description = "HTTP 상태 코드", example = "400")
             int status,
+            @Schema(description = "에러 코드", example = "INVALID_FILE")
             String errorCode,
+            @Schema(description = "에러 메시지", example = "파일이 비어있습니다")
             String message,
+            @Schema(description = "요청 경로", example = "/api/analysis")
             String path
     ) {
         /**
@@ -153,7 +283,7 @@ public class GlobalExceptionHandler {
         }
 
         public static ErrorResponse of(HttpStatus httpStatus, String errorCode,
-                                      String message, String path) {
+                                       String message, String path) {
             return new ErrorResponse(
                     LocalDateTime.now(),
                     httpStatus.value(),

--- a/src/main/java/com/electricip/loganalyzer/application/AnalysisService.java
+++ b/src/main/java/com/electricip/loganalyzer/application/AnalysisService.java
@@ -3,6 +3,9 @@ package com.electricip.loganalyzer.application;
 import com.electricip.loganalyzer.domain.AnalysisResult;
 import com.electricip.loganalyzer.domain.InvalidCsvFormatException;
 import com.electricip.loganalyzer.domain.IpInfo;
+import com.electricip.loganalyzer.domain.exception.FileTooLargeException;
+import com.electricip.loganalyzer.domain.exception.InvalidFileException;
+import com.electricip.loganalyzer.domain.exception.LogParsingException;
 import com.electricip.loganalyzer.infrastructure.client.IpInfoClient;
 import com.electricip.loganalyzer.infrastructure.parser.CsvLogParser;
 import com.electricip.loganalyzer.infrastructure.repository.AnalysisRepository;
@@ -34,25 +37,26 @@ public class AnalysisService {
     
     /**
      * 로그 분석
-     * 
-     * @throws IllegalArgumentException 파일이 유효하지 않은 경우
-     * @throws RuntimeException 분석 실패 시
+     *
+     * @throws InvalidFileException 파일이 유효하지 않은 경우
+     * @throws FileTooLargeException 파일 크기 초과 시
+     * @throws LogParsingException 분석 실패 시
      */
     public AnalysisResult analyze(MultipartFile file) {
         Objects.requireNonNull(file, "file은 null일 수 없습니다");
         validateFile(file);
-        
+
         var startTime = System.currentTimeMillis();
-        
+
         log.info("분석 시작: file={}, size={}bytes", file.getOriginalFilename(), file.getSize());
-        
+
         try {
             // 1. 파싱
             var parseResult = logParser.parse(file.getInputStream());
             var logs = parseResult.logs();
 
             if (logs.isEmpty()) {
-                throw new IllegalStateException("유효한 로그가 없습니다");
+                throw new LogParsingException("유효한 로그가 없습니다");
             }
 
             // 2. 통계 계산
@@ -81,12 +85,12 @@ public class AnalysisService {
 
             return result;
 
-        } catch (InvalidCsvFormatException | IllegalArgumentException | IllegalStateException e) {
+        } catch (InvalidCsvFormatException | LogParsingException e) {
             log.error("분석 실패: {}", e.getMessage(), e);
             throw e;
         } catch (Exception e) {
             log.error("분석 실패: {}", e.getMessage(), e);
-            throw new RuntimeException("로그 분석에 실패했습니다: " + e.getMessage(), e);
+            throw new LogParsingException("로그 분석에 실패했습니다: " + e.getMessage(), e);
         }
     }
 
@@ -109,18 +113,19 @@ public class AnalysisService {
 
     private void validateFile(MultipartFile file) {
         if (file.isEmpty()) {
-            throw new IllegalArgumentException("파일이 비어있습니다");
+            throw new InvalidFileException("파일이 비어있습니다");
         }
-        
+
         var maxBytes = maxFileSizeMb * 1024L * 1024L;
         if (file.getSize() > maxBytes) {
-            throw new IllegalArgumentException(
-                    String.format("파일 크기 초과 (최대 %dMB)", maxFileSizeMb));
+            throw new FileTooLargeException(
+                    String.format("파일 크기 초과 (최대 %dMB)", maxFileSizeMb),
+                    file.getSize(), maxBytes);
         }
-        
+
         var filename = file.getOriginalFilename();
         if (filename == null || !filename.toLowerCase().endsWith(".csv")) {
-            throw new IllegalArgumentException("CSV 파일만 업로드 가능합니다");
+            throw new InvalidFileException("CSV 파일만 업로드 가능합니다");
         }
     }
     

--- a/src/main/java/com/electricip/loganalyzer/config/OpenApiConfig.java
+++ b/src/main/java/com/electricip/loganalyzer/config/OpenApiConfig.java
@@ -21,13 +21,30 @@ public class OpenApiConfig {
                         .title("Log Analyzer API")
                         .version("1.0.0")
                         .description("""
-                                # Log Analyzer API
-                                
-                                ## 주요 기능
+                                ## CSV 형식의 접속 로그를 분석해 요약 통계를 생성하고, IP 정보를 결합해 리포트를 제공하는 애플리케이션
+
+                                ### 주요 기능
                                 - CSV 로그 파싱 (스트리밍)
                                 - 통계 분석
                                 - ipinfo API 연동
                                 - Caffeine 캐싱
+
+                                ### 에러 코드
+
+                                | 에러 코드 | HTTP 상태 | 설명 |
+                                |-----------|-----------|------|
+                                | `INVALID_CSV_FORMAT` | 400 | CSV 헤더 누락 등 형식 오류 |
+                                | `INVALID_FILE` | 400 | 빈 파일, 지원하지 않는 확장자 |
+                                | `LOG_PARSING_ERROR` | 400 | 로그 파싱 실패 |
+                                | `TOO_MANY_PARSING_ERRORS` | 422 | 파싱 에러 과다 (유효한 로그 없음) |
+                                | `FILE_TOO_LARGE` | 413 | 파일 크기 초과 |
+                                | `NOT_FOUND` | 404 | 분석 결과 미발견 |
+                                | `DUPLICATE_ID` | 409 | 중복 분석 ID |
+                                | `RATE_LIMIT_EXCEEDED` | 429 | ipinfo API rate limit 초과 |
+                                | `IPINFO_AUTH_ERROR` | 502 | ipinfo API 인증 실패 |
+                                | `IPINFO_SERVER_ERROR` | 502 | ipinfo 서버 오류 |
+                                | `IPINFO_ERROR` | 502 | ipinfo API 기타 오류 |
+                                | `INTERNAL_ERROR` | 500 | 서버 내부 오류 |
                                 """));
     }
 }

--- a/src/main/java/com/electricip/loganalyzer/domain/InvalidCsvFormatException.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/InvalidCsvFormatException.java
@@ -1,16 +1,18 @@
 package com.electricip.loganalyzer.domain;
 
+import com.electricip.loganalyzer.domain.exception.LogAnalyzerException;
+
 import java.util.List;
 
 /**
  * CSV 형식이 올바르지 않을 때 발생하는 도메인 예외
  */
-public class InvalidCsvFormatException extends RuntimeException {
+public class InvalidCsvFormatException extends LogAnalyzerException {
 
     private final List<String> missingHeaders;
 
     public InvalidCsvFormatException(String message, List<String> missingHeaders) {
-        super(message);
+        super("INVALID_CSV_FORMAT", message);
         this.missingHeaders = (missingHeaders != null) ? List.copyOf(missingHeaders) : List.of();
     }
 

--- a/src/main/java/com/electricip/loganalyzer/domain/exception/AnalysisNotFoundException.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/exception/AnalysisNotFoundException.java
@@ -1,0 +1,18 @@
+package com.electricip.loganalyzer.domain.exception;
+
+/**
+ * 분석 결과를 찾을 수 없을 때 발생하는 예외
+ */
+public class AnalysisNotFoundException extends LogAnalyzerException {
+
+    private final String analysisId;
+
+    public AnalysisNotFoundException(String analysisId) {
+        super("NOT_FOUND", "분석 결과를 찾을 수 없습니다: " + analysisId);
+        this.analysisId = analysisId;
+    }
+
+    public String getAnalysisId() {
+        return analysisId;
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/domain/exception/DuplicateAnalysisIdException.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/exception/DuplicateAnalysisIdException.java
@@ -1,0 +1,18 @@
+package com.electricip.loganalyzer.domain.exception;
+
+/**
+ * 중복된 분석 ID가 존재할 때 발생하는 예외
+ */
+public class DuplicateAnalysisIdException extends LogAnalyzerException {
+
+    private final String analysisId;
+
+    public DuplicateAnalysisIdException(String analysisId) {
+        super("DUPLICATE_ID", "이미 존재하는 분석 ID입니다: " + analysisId);
+        this.analysisId = analysisId;
+    }
+
+    public String getAnalysisId() {
+        return analysisId;
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/domain/exception/FileTooLargeException.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/exception/FileTooLargeException.java
@@ -1,0 +1,24 @@
+package com.electricip.loganalyzer.domain.exception;
+
+/**
+ * 업로드 파일이 허용 크기를 초과했을 때 발생하는 예외
+ */
+public class FileTooLargeException extends InvalidFileException {
+
+    private final long fileSizeBytes;
+    private final long maxSizeBytes;
+
+    public FileTooLargeException(String message, long fileSizeBytes, long maxSizeBytes) {
+        super("FILE_TOO_LARGE", message);
+        this.fileSizeBytes = fileSizeBytes;
+        this.maxSizeBytes = maxSizeBytes;
+    }
+
+    public long getFileSizeBytes() {
+        return fileSizeBytes;
+    }
+
+    public long getMaxSizeBytes() {
+        return maxSizeBytes;
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/domain/exception/InvalidFileException.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/exception/InvalidFileException.java
@@ -1,0 +1,16 @@
+package com.electricip.loganalyzer.domain.exception;
+
+/**
+ * 유효하지 않은 파일 업로드 시 발생하는 예외
+ * (빈 파일, 지원하지 않는 확장자 등)
+ */
+public class InvalidFileException extends LogAnalyzerException {
+
+    public InvalidFileException(String message) {
+        super("INVALID_FILE", message);
+    }
+
+    protected InvalidFileException(String errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/domain/exception/LogAnalyzerException.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/exception/LogAnalyzerException.java
@@ -1,0 +1,26 @@
+package com.electricip.loganalyzer.domain.exception;
+
+import java.util.Objects;
+
+/**
+ * 로그 분석 애플리케이션의 최상위 예외
+ * — 모든 도메인/인프라 예외가 이 클래스를 상속하여 errorCode를 제공한다
+ */
+public abstract class LogAnalyzerException extends RuntimeException {
+
+    private final String errorCode;
+
+    protected LogAnalyzerException(String errorCode, String message) {
+        super(message);
+        this.errorCode = Objects.requireNonNull(errorCode, "errorCode는 null일 수 없습니다");
+    }
+
+    protected LogAnalyzerException(String errorCode, String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = Objects.requireNonNull(errorCode, "errorCode는 null일 수 없습니다");
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/domain/exception/LogParsingException.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/exception/LogParsingException.java
@@ -1,0 +1,28 @@
+package com.electricip.loganalyzer.domain.exception;
+
+/**
+ * 로그 파싱 중 발생하는 일반 예외
+ */
+public class LogParsingException extends LogAnalyzerException {
+
+    private final long lineNumber;
+
+    public LogParsingException(String message) {
+        super("LOG_PARSING_ERROR", message);
+        this.lineNumber = -1;
+    }
+
+    public LogParsingException(String message, long lineNumber) {
+        super("LOG_PARSING_ERROR", message);
+        this.lineNumber = lineNumber;
+    }
+
+    public LogParsingException(String message, Throwable cause) {
+        super("LOG_PARSING_ERROR", message, cause);
+        this.lineNumber = -1;
+    }
+
+    public long getLineNumber() {
+        return lineNumber;
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/domain/exception/TooManyParsingErrorsException.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/exception/TooManyParsingErrorsException.java
@@ -1,0 +1,39 @@
+package com.electricip.loganalyzer.domain.exception;
+
+import com.electricip.loganalyzer.domain.ParseError;
+
+import java.util.List;
+
+/**
+ * 파싱 에러가 과다하여 유효한 로그가 없을 때 발생하는 예외
+ */
+public class TooManyParsingErrorsException extends LogAnalyzerException {
+
+    private final long totalLines;
+    private final long errorCount;
+    private final List<ParseError> errors;
+
+    public TooManyParsingErrorsException(String message, long totalLines, long errorCount) {
+        this(message, totalLines, errorCount, List.of());
+    }
+
+    public TooManyParsingErrorsException(String message, long totalLines, long errorCount,
+                                         List<ParseError> errors) {
+        super("TOO_MANY_PARSING_ERRORS", message);
+        this.totalLines = totalLines;
+        this.errorCount = errorCount;
+        this.errors = (errors != null) ? List.copyOf(errors) : List.of();
+    }
+
+    public long getTotalLines() {
+        return totalLines;
+    }
+
+    public long getErrorCount() {
+        return errorCount;
+    }
+
+    public List<ParseError> getErrors() {
+        return errors;
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoAuthException.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoAuthException.java
@@ -6,6 +6,6 @@ package com.electricip.loganalyzer.infrastructure.client;
 public class IpInfoAuthException extends IpInfoException {
 
     public IpInfoAuthException(String message) {
-        super(message);
+        super("IPINFO_AUTH_ERROR", message);
     }
 }

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoException.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoException.java
@@ -1,15 +1,21 @@
 package com.electricip.loganalyzer.infrastructure.client;
 
+import com.electricip.loganalyzer.domain.exception.LogAnalyzerException;
+
 /**
  * ipinfo API 호출 시 발생하는 기본 예외
  */
-public class IpInfoException extends RuntimeException {
+public class IpInfoException extends LogAnalyzerException {
 
     public IpInfoException(String message) {
-        super(message);
+        super("IPINFO_ERROR", message);
     }
 
     public IpInfoException(String message, Throwable cause) {
-        super(message, cause);
+        super("IPINFO_ERROR", message, cause);
+    }
+
+    protected IpInfoException(String errorCode, String message) {
+        super(errorCode, message);
     }
 }

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoServerException.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoServerException.java
@@ -6,6 +6,6 @@ package com.electricip.loganalyzer.infrastructure.client;
 public class IpInfoServerException extends IpInfoException {
 
     public IpInfoServerException(String message) {
-        super(message);
+        super("IPINFO_SERVER_ERROR", message);
     }
 }

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/client/RateLimitExceededException.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/client/RateLimitExceededException.java
@@ -6,6 +6,6 @@ package com.electricip.loganalyzer.infrastructure.client;
 public class RateLimitExceededException extends IpInfoException {
 
     public RateLimitExceededException(String message) {
-        super(message);
+        super("RATE_LIMIT_EXCEEDED", message);
     }
 }

--- a/src/test/java/com/electricip/loganalyzer/api/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/electricip/loganalyzer/api/GlobalExceptionHandlerTest.java
@@ -1,6 +1,16 @@
 package com.electricip.loganalyzer.api;
 
 import com.electricip.loganalyzer.domain.InvalidCsvFormatException;
+import com.electricip.loganalyzer.domain.exception.AnalysisNotFoundException;
+import com.electricip.loganalyzer.domain.exception.DuplicateAnalysisIdException;
+import com.electricip.loganalyzer.domain.exception.FileTooLargeException;
+import com.electricip.loganalyzer.domain.exception.InvalidFileException;
+import com.electricip.loganalyzer.domain.exception.LogParsingException;
+import com.electricip.loganalyzer.domain.exception.TooManyParsingErrorsException;
+import com.electricip.loganalyzer.infrastructure.client.IpInfoAuthException;
+import com.electricip.loganalyzer.infrastructure.client.IpInfoException;
+import com.electricip.loganalyzer.infrastructure.client.IpInfoServerException;
+import com.electricip.loganalyzer.infrastructure.client.RateLimitExceededException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -18,7 +28,7 @@ class GlobalExceptionHandlerTest {
 
     @Nested
     @DisplayName("InvalidCsvFormatException 핸들러")
-    class InvalidCsvFormatExceptionTest {
+    class InvalidCsvFormatTest {
 
         @Test
         @DisplayName("400 Bad Request로 응답한다")
@@ -46,49 +56,145 @@ class GlobalExceptionHandlerTest {
     }
 
     @Nested
-    @DisplayName("IllegalStateException 핸들러")
-    class IllegalStateExceptionTest {
+    @DisplayName("InvalidFileException 핸들러")
+    class InvalidFileTest {
 
         @Test
-        @DisplayName("422 Unprocessable Entity로 응답한다")
-        void shouldReturn422() {
-            var ex = new IllegalStateException("유효한 로그가 없습니다");
+        @DisplayName("400 Bad Request로 응답한다")
+        void shouldReturn400() {
+            var ex = new InvalidFileException("파일이 비어있습니다");
 
-            var response = handler.handleIllegalState(ex, request);
+            var response = handler.handleInvalidFile(ex, request);
 
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
             assertThat(response.getBody()).isNotNull();
-            assertThat(response.getBody().errorCode()).isEqualTo("INVALID_STATE");
-            assertThat(response.getBody().message()).isEqualTo("유효한 로그가 없습니다");
-        }
-
-        @Test
-        @DisplayName("상태 코드가 422이다")
-        void shouldHaveStatusCode422() {
-            var ex = new IllegalStateException("test");
-
-            var response = handler.handleIllegalState(ex, request);
-
-            assertThat(response.getBody()).isNotNull();
-            assertThat(response.getBody().status()).isEqualTo(422);
+            assertThat(response.getBody().errorCode()).isEqualTo("INVALID_FILE");
         }
     }
 
     @Nested
-    @DisplayName("기존 핸들러 정상 동작 확인")
-    class ExistingHandlersTest {
+    @DisplayName("FileTooLargeException 핸들러")
+    class FileTooLargeTest {
 
         @Test
-        @DisplayName("IllegalArgumentException은 400으로 응답한다")
-        void shouldReturn400ForIllegalArgument() {
-            var ex = new IllegalArgumentException("파일이 비어있습니다");
+        @DisplayName("413 Payload Too Large로 응답한다")
+        void shouldReturn413() {
+            var ex = new FileTooLargeException("파일 크기 초과 (최대 50MB)", 100_000_000L, 52_428_800L);
 
-            var response = handler.handleIllegalArgument(ex, request);
+            var response = handler.handleFileTooLarge(ex, request);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().errorCode()).isEqualTo("FILE_TOO_LARGE");
+        }
+    }
+
+    @Nested
+    @DisplayName("LogParsingException 핸들러")
+    class LogParsingTest {
+
+        @Test
+        @DisplayName("400 Bad Request로 응답한다")
+        void shouldReturn400() {
+            var ex = new LogParsingException("유효한 로그가 없습니다");
+
+            var response = handler.handleLogParsing(ex, request);
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
             assertThat(response.getBody()).isNotNull();
-            assertThat(response.getBody().errorCode()).isEqualTo("INVALID_REQUEST");
+            assertThat(response.getBody().errorCode()).isEqualTo("LOG_PARSING_ERROR");
         }
+    }
+
+    @Nested
+    @DisplayName("TooManyParsingErrorsException 핸들러")
+    class TooManyParsingErrorsTest {
+
+        @Test
+        @DisplayName("422 Unprocessable Entity로 응답한다")
+        void shouldReturn422() {
+            var ex = new TooManyParsingErrorsException("파싱 에러 과다", 100, 95);
+
+            var response = handler.handleTooManyParsingErrors(ex, request);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().errorCode()).isEqualTo("TOO_MANY_PARSING_ERRORS");
+        }
+    }
+
+    @Nested
+    @DisplayName("AnalysisNotFoundException 핸들러")
+    class AnalysisNotFoundTest {
+
+        @Test
+        @DisplayName("404 Not Found로 응답한다")
+        void shouldReturn404() {
+            var ex = new AnalysisNotFoundException("abc-123");
+
+            var response = handler.handleAnalysisNotFound(ex, request);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().errorCode()).isEqualTo("NOT_FOUND");
+            assertThat(response.getBody().message()).contains("abc-123");
+        }
+    }
+
+    @Nested
+    @DisplayName("DuplicateAnalysisIdException 핸들러")
+    class DuplicateAnalysisIdTest {
+
+        @Test
+        @DisplayName("409 Conflict로 응답한다")
+        void shouldReturn409() {
+            var ex = new DuplicateAnalysisIdException("abc-123");
+
+            var response = handler.handleDuplicateAnalysisId(ex, request);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().errorCode()).isEqualTo("DUPLICATE_ID");
+        }
+    }
+
+    @Nested
+    @DisplayName("RateLimitExceededException 핸들러")
+    class RateLimitTest {
+
+        @Test
+        @DisplayName("429 Too Many Requests로 응답한다")
+        void shouldReturn429() {
+            var ex = new RateLimitExceededException("rate limit 초과");
+
+            var response = handler.handleRateLimitExceeded(ex, request);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().errorCode()).isEqualTo("RATE_LIMIT_EXCEEDED");
+        }
+    }
+
+    @Nested
+    @DisplayName("IpInfoException 핸들러")
+    class IpInfoTest {
+
+        @Test
+        @DisplayName("502 Bad Gateway로 응답한다")
+        void shouldReturn502() {
+            var ex = new IpInfoException("IP 정보 조회 실패");
+
+            var response = handler.handleIpInfoException(ex, request);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_GATEWAY);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().errorCode()).isEqualTo("IPINFO_ERROR");
+        }
+    }
+
+    @Nested
+    @DisplayName("일반 예외 핸들러")
+    class GeneralExceptionTest {
 
         @Test
         @DisplayName("일반 Exception은 500으로 응답한다")

--- a/src/test/java/com/electricip/loganalyzer/domain/InvalidCsvFormatExceptionTest.java
+++ b/src/test/java/com/electricip/loganalyzer/domain/InvalidCsvFormatExceptionTest.java
@@ -1,5 +1,6 @@
 package com.electricip.loganalyzer.domain;
 
+import com.electricip.loganalyzer.domain.exception.LogAnalyzerException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -71,9 +72,17 @@ class InvalidCsvFormatExceptionTest {
     }
 
     @Test
-    @DisplayName("RuntimeException을 상속한다")
-    void shouldExtendRuntimeException() {
+    @DisplayName("LogAnalyzerException을 상속한다")
+    void shouldExtendLogAnalyzerException() {
         var ex = new InvalidCsvFormatException("test");
+        assertThat(ex).isInstanceOf(LogAnalyzerException.class);
         assertThat(ex).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    @DisplayName("errorCode가 INVALID_CSV_FORMAT이다")
+    void shouldHaveCorrectErrorCode() {
+        var ex = new InvalidCsvFormatException("test");
+        assertThat(ex.getErrorCode()).isEqualTo("INVALID_CSV_FORMAT");
     }
 }

--- a/src/test/java/com/electricip/loganalyzer/infrastructure/client/IpInfoErrorHandlerTest.java
+++ b/src/test/java/com/electricip/loganalyzer/infrastructure/client/IpInfoErrorHandlerTest.java
@@ -1,5 +1,6 @@
 package com.electricip.loganalyzer.infrastructure.client;
 
+import com.electricip.loganalyzer.domain.exception.LogAnalyzerException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -110,6 +111,43 @@ class IpInfoErrorHandlerTest {
                         .isInstanceOf(IpInfoException.class)
                         .hasMessageContaining("404");
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("LogAnalyzerException 상속 검증")
+    class InheritanceTest {
+
+        @Test
+        @DisplayName("IpInfoException은 LogAnalyzerException을 상속한다")
+        void ipInfoExceptionShouldExtendLogAnalyzerException() {
+            var ex = new IpInfoException("test");
+            assertThat(ex).isInstanceOf(LogAnalyzerException.class);
+            assertThat(ex.getErrorCode()).isEqualTo("IPINFO_ERROR");
+        }
+
+        @Test
+        @DisplayName("RateLimitExceededException은 LogAnalyzerException을 상속한다")
+        void rateLimitShouldExtendLogAnalyzerException() {
+            var ex = new RateLimitExceededException("test");
+            assertThat(ex).isInstanceOf(LogAnalyzerException.class);
+            assertThat(ex.getErrorCode()).isEqualTo("RATE_LIMIT_EXCEEDED");
+        }
+
+        @Test
+        @DisplayName("IpInfoAuthException은 LogAnalyzerException을 상속한다")
+        void authShouldExtendLogAnalyzerException() {
+            var ex = new IpInfoAuthException("test");
+            assertThat(ex).isInstanceOf(LogAnalyzerException.class);
+            assertThat(ex.getErrorCode()).isEqualTo("IPINFO_AUTH_ERROR");
+        }
+
+        @Test
+        @DisplayName("IpInfoServerException은 LogAnalyzerException을 상속한다")
+        void serverShouldExtendLogAnalyzerException() {
+            var ex = new IpInfoServerException("test");
+            assertThat(ex).isInstanceOf(LogAnalyzerException.class);
+            assertThat(ex.getErrorCode()).isEqualTo("IPINFO_SERVER_ERROR");
         }
     }
 }


### PR DESCRIPTION
## Summary
범용 예외(IllegalArgument/IllegalState/RuntimeException) 사용을 제거하고,
LogAnalyzerException 기반 도메인 예외 계층으로 통합하여
에러 코드 중심의 구조화된 응답과 일관된 HTTP 매핑을 제공하도록 개선.

---

## Context

### Issue #9 
- Issue: #9 
- 범용 예외 사용으로 인해 에러 원인 파악이 어렵고, 프론트엔드에 세부 에러 정보를 전달하기 어려움
- 동일한 실패 케이스가 호출 경로에 따라 서로 다른 예외로 나타나며, GlobalExceptionHandler 매핑이 분산됨
- IpInfo / CSV 파싱 / 파일 검증 등 주요 에러 케이스를 errorCode 기반으로 통합 관리할 필요가 있음

### Background
- API 에러 응답은 “메시지 문자열”보다 **errorCode 중심**으로 소비되어야 프론트에서 안정적으로 분기 가능
- 예외 생성/전파는 도메인 의미를 잃지 않아야 하며,
  Application 레이어에서 범용 예외로 뭉개지지 않아야 함
- 따라서 LogAnalyzerException(abstract, errorCode 포함)을 최상위로 두고
  주요 실패 케이스를 하위 타입으로 구체화하여 일관된 매핑을 제공하도록 설계를 정리함

---

## Changes

### Domain
- LogAnalyzerException 기반 예외 계층으로 통합
  - InvalidCsvFormatException: LogAnalyzerException 상속으로 마이그레이션 (missingHeaders 유지)
  - LogParsingException: lineNumber 필드 추가
  - TooManyParsingErrorsException: errors(List<ParseError>) 필드 추가
  - FileTooLargeException 신규 (InvalidFileException 상속, 413 매핑 대상)
  - AnalysisNotFoundException 신규 (404)
  - DuplicateAnalysisIdException 신규 (409)

### Infrastructure
- IpInfo 예외 계층을 LogAnalyzerException 기반으로 마이그레이션
  - IpInfoException 및 하위 예외에 errorCode 전달
  - RateLimitExceededException / IpInfoAuthException / IpInfoServerException 포함

### Application
- AnalysisService에서 범용 예외를 도메인 예외로 치환/전파
  - IllegalArgumentException → InvalidFileException / FileTooLargeException
  - IllegalStateException / RuntimeException → LogParsingException 등 도메인 예외로 전환

### API
- AnalysisController: getById()에서 AnalysisNotFoundException throw
- GlobalExceptionHandler 전면 리팩토링
  - 도메인 예외별 handler 추가 및 HTTP 상태 코드 매핑 정리
  - 기존 IllegalArgumentException / NullPointerException / IllegalStateException 핸들러 제거(도메인 예외로 대체)
  - MaxUploadSizeExceededException(413), Exception(500) 매핑은 유지

### HTTP 매핑
- 400: InvalidCsvFormatException, InvalidFileException, LogParsingException
- 422: TooManyParsingErrorsException
- 413: FileTooLargeException, MaxUploadSizeExceededException
- 404: AnalysisNotFoundException
- 409: DuplicateAnalysisIdException
- 429: RateLimitExceededException
- 502: IpInfoException(나머지)
- 500: LogAnalyzerException(catch-all), Exception

### Test
- InvalidCsvFormatExceptionTest: errorCode/상속 구조 검증 추가
- GlobalExceptionHandlerTest: 새 매핑 테스트 추가, 제거된 매핑 테스트 삭제
- IpInfoErrorHandlerTest: IpInfo 예외의 LogAnalyzerException 상속 및 errorCode 검증

---

## Code Convention Checklist

### 1. 객체 생성 & 수명 관리
- [x] 예외 생성 규칙을 도메인 예외 계층으로 캡슐화했다

### 2. 불변성 & 스레드 안정성
- [x] 예외 응답은 errorCode 중심으로 구조화되어 분기 가능하다

### 3. 메서드 계약
- [x] 실패 케이스는 범용 예외가 아닌 도메인 의미를 가진 예외로 드러난다
- [x] Application 계층에서 도메인 예외가 뭉개지지 않고 전파된다

### 4. 계층 분리
- [x] Infrastructure 오류도 도메인 예외 계층으로 통합하여 API에 일관되게 전달한다
- [x] API 레이어는 예외를 HTTP 응답으로 매핑하는 책임만 가진다

### 5. 예외 & 로깅
- [x] errorCode 기반 응답으로 원인 추적과 프론트 분기 가능성을 강화했다

---

## Behavior Change

### Before
- 범용 예외 중심이라 원인 구분이 어렵고, 프론트에서 에러 케이스별 분기가 제한적
- Application 레이어에서 예외가 RuntimeException으로 감싸져 GlobalExceptionHandler 매핑이 불안정

### After
- errorCode 기반 도메인 예외 계층으로 통일되어 원인 구분 가능
- API에서 일관된 HTTP 상태 코드 + errorCode 응답 제공
- 도메인 예외가 그대로 전파되어 GlobalExceptionHandler에서 정확히 매핑됨

---

## Test
```bash
./gradlew test
./gradlew compileJava
```

## Risk & Rollback
- Risk: 예외 타입 및 HTTP 매핑 변경으로 클라이언트가 특정 메시지/상태코드에 의존하고 있었다면 영향 가능
- Rollback: 예외 계층 통합 및 GlobalExceptionHandler 변경 커밋을 순서대로 롤백하면 기존 동작으로 복구 가능