### PR TITLE
fix: 도메인 예외 전파 및 파싱 오류 처리 정비

### DIFF
--- a/src/main/java/com/electricip/loganalyzer/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/electricip/loganalyzer/api/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import com.electricip.loganalyzer.infrastructure.client.RateLimitExceededExcepti
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -27,6 +28,13 @@ import java.time.LocalDateTime;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private final int maxFileSizeMb;
+
+    public GlobalExceptionHandler(
+            @Value("${log-analysis.max-file-size-mb:50}") int maxFileSizeMb) {
+        this.maxFileSizeMb = maxFileSizeMb;
+    }
 
     /**
      * InvalidCsvFormatException 처리 → 400
@@ -232,7 +240,7 @@ public class GlobalExceptionHandler {
                 .body(ErrorResponse.of(
                         HttpStatus.PAYLOAD_TOO_LARGE,
                         "FILE_TOO_LARGE",
-                        "파일 크기 초과 (최대 50MB)",
+                        String.format("파일 크기 초과 (최대 %dMB)", maxFileSizeMb),
                         request.getRequestURI()
                 ));
     }

--- a/src/main/java/com/electricip/loganalyzer/application/AnalysisService.java
+++ b/src/main/java/com/electricip/loganalyzer/application/AnalysisService.java
@@ -1,11 +1,12 @@
 package com.electricip.loganalyzer.application;
 
 import com.electricip.loganalyzer.domain.AnalysisResult;
-import com.electricip.loganalyzer.domain.InvalidCsvFormatException;
 import com.electricip.loganalyzer.domain.IpInfo;
 import com.electricip.loganalyzer.domain.exception.FileTooLargeException;
 import com.electricip.loganalyzer.domain.exception.InvalidFileException;
+import com.electricip.loganalyzer.domain.exception.LogAnalyzerException;
 import com.electricip.loganalyzer.domain.exception.LogParsingException;
+import com.electricip.loganalyzer.domain.exception.TooManyParsingErrorsException;
 import com.electricip.loganalyzer.infrastructure.client.IpInfoClient;
 import com.electricip.loganalyzer.infrastructure.parser.CsvLogParser;
 import com.electricip.loganalyzer.infrastructure.repository.AnalysisRepository;
@@ -40,6 +41,7 @@ public class AnalysisService {
      *
      * @throws InvalidFileException 파일이 유효하지 않은 경우
      * @throws FileTooLargeException 파일 크기 초과 시
+     * @throws TooManyParsingErrorsException 파싱 에러 과다 시
      * @throws LogParsingException 분석 실패 시
      */
     public AnalysisResult analyze(MultipartFile file) {
@@ -54,8 +56,15 @@ public class AnalysisService {
             // 1. 파싱
             var parseResult = logParser.parse(file.getInputStream());
             var logs = parseResult.logs();
+            var stats = parseResult.parseStatistics();
 
             if (logs.isEmpty()) {
+                if (stats.errorCount() > 0) {
+                    throw new TooManyParsingErrorsException(
+                            String.format("유효한 로그가 없습니다 (전체 %d줄 중 %d줄 에러)",
+                                    stats.totalLines(), stats.errorCount()),
+                            stats.totalLines(), stats.errorCount(), stats.errorSamples());
+                }
                 throw new LogParsingException("유효한 로그가 없습니다");
             }
 
@@ -85,12 +94,12 @@ public class AnalysisService {
 
             return result;
 
-        } catch (InvalidCsvFormatException | LogParsingException e) {
+        } catch (LogAnalyzerException e) {
             log.error("분석 실패: {}", e.getMessage(), e);
             throw e;
         } catch (Exception e) {
-            log.error("분석 실패: {}", e.getMessage(), e);
-            throw new LogParsingException("로그 분석에 실패했습니다: " + e.getMessage(), e);
+            log.error("분석 실패 (내부 오류): {}", e.getMessage(), e);
+            throw new RuntimeException("로그 분석에 실패했습니다: " + e.getMessage(), e);
         }
     }
 

--- a/src/test/java/com/electricip/loganalyzer/api/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/electricip/loganalyzer/api/GlobalExceptionHandlerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import java.util.List;
 
@@ -23,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class GlobalExceptionHandlerTest {
 
-    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler(50);
     private final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/analysis");
 
     @Nested
@@ -189,6 +190,36 @@ class GlobalExceptionHandlerTest {
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_GATEWAY);
             assertThat(response.getBody()).isNotNull();
             assertThat(response.getBody().errorCode()).isEqualTo("IPINFO_ERROR");
+        }
+    }
+
+    @Nested
+    @DisplayName("MaxUploadSizeExceededException 핸들러")
+    class MaxUploadSizeTest {
+
+        @Test
+        @DisplayName("413으로 응답하며 설정된 최대 크기가 메시지에 포함된다")
+        void shouldReturn413WithConfiguredMaxSize() {
+            var ex = new MaxUploadSizeExceededException(50 * 1024 * 1024L);
+
+            var response = handler.handleMaxUploadSizeExceeded(ex, request);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().errorCode()).isEqualTo("FILE_TOO_LARGE");
+            assertThat(response.getBody().message()).contains("50MB");
+        }
+
+        @Test
+        @DisplayName("다른 설정값일 때도 메시지에 반영된다")
+        void shouldReflectCustomMaxSize() {
+            var customHandler = new GlobalExceptionHandler(100);
+            var ex = new MaxUploadSizeExceededException(100 * 1024 * 1024L);
+
+            var response = customHandler.handleMaxUploadSizeExceeded(ex, request);
+
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().message()).contains("100MB");
         }
     }
 


### PR DESCRIPTION
## Summary
<!-- 이 PR이 무엇을 변경하는지 한 줄 요약 -->
분석 파이프라인 전반에서 도메인 예외가 의도대로 전파되지 않던 문제와
파일 업로드 / 파싱 오류 처리의 불일관성을 정리

## Context
<!-- 왜 이 변경이 필요한지 / 배경 -->
- Issue: #9 
### Background: 
기존 구조에서의 다음 문제 개선
- AnalysisService에서 도메인 예외까지 RuntimeException으로 감싸
- GlobalExceptionHandler에서 세부 원인을 구분할 수 없음
- MaxUploadSizeExceededException 에러 메시지가 하드코딩되어
설정값 변경 시 메시지와 불일치
- 파싱 오류가 다수 발생했음에도 클라이언트에 의미 있는 에러 정보 전달 불가

## Changes
<!-- 변경 사항을 계층별로 간결하게 -->

### 1. 도메인 예외 전파 정리
- `AnalysisService`
  - `LogAnalyzerException` 계열 예외는 그대로 rethrow
  - 예측 불가 예외만 `RuntimeException`으로 래핑 → 500 처리
- 도메인 예외 → HTTP 상태 코드 매핑이 `GlobalExceptionHandler`에서 정상 동작

### 2. 파일 업로드 크기 오류 메시지 개선
- `GlobalExceptionHandler`
  - `@Value("${log-analysis.max-file-size-mb:50}")` 생성자 주입
  - 에러 메시지를 설정값 기반으로 동적 구성
- 테스트에서 50MB / 100MB 설정값에 따른 메시지 반영 검증

### 3. 파싱 오류 임계치 예외 연결
- `AnalysisService.analyze()`
  - 파싱 결과가 없고 에러만 존재하는 경우  
    → `TooManyParsingErrorsException` 발생
  - 에러 샘플(`errorSamples`)을 예외에 포함하여 클라이언트로 전달
- 헤더만 있는 정상 파일은 기존대로 `LogParsingException` 유지

---

## Code Convention Checklist
> 본 PR은 프로젝트 코드 컨벤션을 기준으로 검토합니다.  
> 세부 기준은 `docs/CODE_CONVENTION.md`를 따릅니다.

### 1. 객체 생성 & 수명 관리
- [ ] 생성 로직은 생성자 대신 **정적 팩터리 메서드** 또는 **빌더**로 캡슐화했다
- [ ] 매개변수가 많은 객체는 **Builder 패턴**을 사용했다
- [ ] 의존 객체는 **생성자 주입**으로 전달했다
- [ ] 자원 사용 시 **try-with-resources**를 적용했다

### 2. 불변성 & 스레드 안정성
- [ ] 도메인 객체는 **불변(record / @Value)** 으로 설계했다
- [ ] 내부 상태는 외부에서 수정할 수 없도록 보호했다
- [ ] 동시 접근 가능 구조에는 **thread-safe 컬렉션**을 사용했다

### 3. 메서드 계약
- [ ] public 메서드는 **매개변수 유효성 검사**를 수행한다
- [ ] `null` 대신 **Optional 또는 빈 컬렉션**을 반환한다
- [ ] 컬렉션/배열은 **방어적 복사** 또는 불변 래핑을 적용했다
- [ ] 실패 케이스는 **Fail-Fast**로 드러난다

### 4. 계층 분리
- [ ] Domain 레이어는 **외부 의존성(프레임워크/IO)** 이 없다
- [ ] 외부 시스템 연동은 Infrastructure 레이어에 격리했다
- [ ] Application 레이어는 오케스트레이션 책임만 가진다

### 5. 예외 & 로깅
- [ ] 예외 메시지는 **행동 가능한 정보**를 포함한다
- [ ] 성공/실패 로그 레벨을 구분했다
- [ ] 민감 정보는 로그에 남기지 않았다

---

## Behavior Change
<!-- 사용자/클라이언트 관점에서의 동작 변화 -->
### Before
- 대부분의 오류가 500으로 응답
- 파싱 실패 원인을 클라이언트가 알 수 없음

### After
- 도메인 예외별로 명확한 HTTP 상태 코드 반환
- 파싱 오류 시 구체적인 에러 정보 제공

## Test
```bash
./gradlew test
./gradlew build
```

## Risk & Rollback
- Risk: 에러 응답이 더 명확해짐 (호환성 영향 없음)
- Rollback: 커밋 단위 revert 가능