### PR TITLE
fix(api): 파싱 오류 응답 구조화 및 업로드 크기 예외 개선

### DIFF
--- a/src/main/java/com/electricip/loganalyzer/api/AnalysisController.java
+++ b/src/main/java/com/electricip/loganalyzer/api/AnalysisController.java
@@ -1,6 +1,7 @@
 package com.electricip.loganalyzer.api;
 
 import com.electricip.loganalyzer.api.GlobalExceptionHandler.ErrorResponse;
+import com.electricip.loganalyzer.api.GlobalExceptionHandler.ParsingErrorResponse;
 import com.electricip.loganalyzer.application.AnalysisService;
 import com.electricip.loganalyzer.domain.exception.AnalysisNotFoundException;
 import io.swagger.v3.oas.annotations.Operation;
@@ -48,7 +49,7 @@ public class AnalysisController {
             @ApiResponse(responseCode = "413", description = "파일 크기 초과",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "422", description = "파싱 에러 과다 (유효한 로그 없음)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    content = @Content(schema = @Schema(implementation = ParsingErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })

--- a/src/main/java/com/electricip/loganalyzer/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/electricip/loganalyzer/api/GlobalExceptionHandler.java
@@ -13,7 +13,6 @@ import com.electricip.loganalyzer.infrastructure.client.RateLimitExceededExcepti
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -21,6 +20,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * 전역 예외 처리기
@@ -28,13 +28,6 @@ import java.time.LocalDateTime;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-
-    private final int maxFileSizeMb;
-
-    public GlobalExceptionHandler(
-            @Value("${log-analysis.max-file-size-mb:50}") int maxFileSizeMb) {
-        this.maxFileSizeMb = maxFileSizeMb;
-    }
 
     /**
      * InvalidCsvFormatException 처리 → 400
@@ -116,18 +109,25 @@ public class GlobalExceptionHandler {
      * TooManyParsingErrorsException 처리 → 422
      */
     @ExceptionHandler(TooManyParsingErrorsException.class)
-    public ResponseEntity<ErrorResponse> handleTooManyParsingErrors(
+    public ResponseEntity<ParsingErrorResponse> handleTooManyParsingErrors(
             TooManyParsingErrorsException e, HttpServletRequest request) {
 
         log.error("파싱 에러 과다: {}", e.getMessage());
 
+        var errorSamples = e.getErrors().stream()
+                .map(err -> new ParsingErrorResponse.ParseErrorSample(
+                        err.lineNumber(), err.errorMessage(), err.errorType().name()))
+                .toList();
+
         return ResponseEntity
                 .status(HttpStatus.UNPROCESSABLE_ENTITY)
-                .body(ErrorResponse.of(
-                        HttpStatus.UNPROCESSABLE_ENTITY,
+                .body(ParsingErrorResponse.of(
                         e.getErrorCode(),
                         e.getMessage(),
-                        request.getRequestURI()
+                        request.getRequestURI(),
+                        e.getTotalLines(),
+                        e.getErrorCount(),
+                        errorSamples
                 ));
     }
 
@@ -235,12 +235,17 @@ public class GlobalExceptionHandler {
 
         log.error("파일 크기 초과");
 
+        var maxBytes = e.getMaxUploadSize();
+        var message = (maxBytes > 0)
+                ? String.format("파일 크기 초과 (최대 %dMB)", maxBytes / (1024 * 1024))
+                : "파일 크기 초과";
+
         return ResponseEntity
                 .status(HttpStatus.PAYLOAD_TOO_LARGE)
                 .body(ErrorResponse.of(
                         HttpStatus.PAYLOAD_TOO_LARGE,
                         "FILE_TOO_LARGE",
-                        String.format("파일 크기 초과 (최대 %dMB)", maxFileSizeMb),
+                        message,
                         request.getRequestURI()
                 ));
     }
@@ -300,5 +305,61 @@ public class GlobalExceptionHandler {
                     path
             );
         }
+    }
+
+    /**
+     * 파싱 에러 과다 응답 — ErrorResponse 필드 + 파싱 통계/샘플
+     */
+    @Schema(description = "파싱 에러 과다 응답 (422)")
+    public record ParsingErrorResponse(
+            @Schema(description = "에러 발생 시각", example = "2026-02-09T14:30:00")
+            LocalDateTime timestamp,
+            @Schema(description = "HTTP 상태 코드", example = "422")
+            int status,
+            @Schema(description = "에러 코드", example = "TOO_MANY_PARSING_ERRORS")
+            String errorCode,
+            @Schema(description = "에러 메시지", example = "유효한 로그가 없습니다 (전체 100줄 중 100줄 에러)")
+            String message,
+            @Schema(description = "요청 경로", example = "/api/analysis")
+            String path,
+            @Schema(description = "전체 라인 수", example = "100")
+            long totalLines,
+            @Schema(description = "에러 라인 수", example = "100")
+            long errorCount,
+            @Schema(description = "에러 샘플 (최대 10건)")
+            List<ParseErrorSample> errorSamples
+    ) {
+        public ParsingErrorResponse {
+            java.util.Objects.requireNonNull(timestamp, "timestamp는 null일 수 없습니다");
+            java.util.Objects.requireNonNull(errorCode, "errorCode는 null일 수 없습니다");
+            java.util.Objects.requireNonNull(path, "path는 null일 수 없습니다");
+            message = (message != null) ? message : "알 수 없는 오류";
+            errorSamples = (errorSamples != null) ? List.copyOf(errorSamples) : List.of();
+        }
+
+        public static ParsingErrorResponse of(String errorCode, String message, String path,
+                                               long totalLines, long errorCount,
+                                               List<ParseErrorSample> errorSamples) {
+            return new ParsingErrorResponse(
+                    LocalDateTime.now(),
+                    HttpStatus.UNPROCESSABLE_ENTITY.value(),
+                    errorCode,
+                    message,
+                    path,
+                    totalLines,
+                    errorCount,
+                    errorSamples
+            );
+        }
+
+        @Schema(description = "파싱 에러 샘플")
+        public record ParseErrorSample(
+                @Schema(description = "에러 발생 라인 번호", example = "42")
+                long lineNumber,
+                @Schema(description = "에러 메시지", example = "잘못된 날짜 형식")
+                String errorMessage,
+                @Schema(description = "에러 유형 (PARSING, VALIDATION, FORMAT)", example = "PARSING")
+                String errorType
+        ) {}
     }
 }

--- a/src/test/java/com/electricip/loganalyzer/api/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/electricip/loganalyzer/api/GlobalExceptionHandlerTest.java
@@ -1,15 +1,14 @@
 package com.electricip.loganalyzer.api;
 
 import com.electricip.loganalyzer.domain.InvalidCsvFormatException;
+import com.electricip.loganalyzer.domain.ParseError;
 import com.electricip.loganalyzer.domain.exception.AnalysisNotFoundException;
 import com.electricip.loganalyzer.domain.exception.DuplicateAnalysisIdException;
 import com.electricip.loganalyzer.domain.exception.FileTooLargeException;
 import com.electricip.loganalyzer.domain.exception.InvalidFileException;
 import com.electricip.loganalyzer.domain.exception.LogParsingException;
 import com.electricip.loganalyzer.domain.exception.TooManyParsingErrorsException;
-import com.electricip.loganalyzer.infrastructure.client.IpInfoAuthException;
 import com.electricip.loganalyzer.infrastructure.client.IpInfoException;
-import com.electricip.loganalyzer.infrastructure.client.IpInfoServerException;
 import com.electricip.loganalyzer.infrastructure.client.RateLimitExceededException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -18,13 +17,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class GlobalExceptionHandlerTest {
 
-    private final GlobalExceptionHandler handler = new GlobalExceptionHandler(50);
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
     private final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/analysis");
 
     @Nested
@@ -112,15 +112,40 @@ class GlobalExceptionHandlerTest {
     class TooManyParsingErrorsTest {
 
         @Test
-        @DisplayName("422 Unprocessable Entity로 응답한다")
-        void shouldReturn422() {
+        @DisplayName("422 Unprocessable Entity로 응답하며 통계를 포함한다")
+        void shouldReturn422WithStats() {
             var ex = new TooManyParsingErrorsException("파싱 에러 과다", 100, 95);
 
             var response = handler.handleTooManyParsingErrors(ex, request);
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
-            assertThat(response.getBody()).isNotNull();
-            assertThat(response.getBody().errorCode()).isEqualTo("TOO_MANY_PARSING_ERRORS");
+            var body = response.getBody();
+            assertThat(body).isNotNull();
+            assertThat(body.errorCode()).isEqualTo("TOO_MANY_PARSING_ERRORS");
+            assertThat(body.totalLines()).isEqualTo(100);
+            assertThat(body.errorCount()).isEqualTo(95);
+            assertThat(body.errorSamples()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("에러 샘플이 응답에 포함된다")
+        void shouldIncludeErrorSamples() {
+            var errors = List.of(
+                    new ParseError(1, "잘못된 날짜 형식", ParseError.ErrorType.PARSING, LocalDateTime.now()),
+                    new ParseError(5, "필수 필드 누락", ParseError.ErrorType.VALIDATION, LocalDateTime.now())
+            );
+            var ex = new TooManyParsingErrorsException("파싱 에러 과다", 10, 10, errors);
+
+            var response = handler.handleTooManyParsingErrors(ex, request);
+
+            var body = response.getBody();
+            assertThat(body).isNotNull();
+            assertThat(body.errorSamples()).hasSize(2);
+            assertThat(body.errorSamples().get(0).lineNumber()).isEqualTo(1);
+            assertThat(body.errorSamples().get(0).errorMessage()).isEqualTo("잘못된 날짜 형식");
+            assertThat(body.errorSamples().get(0).errorType()).isEqualTo("PARSING");
+            assertThat(body.errorSamples().get(1).lineNumber()).isEqualTo(5);
+            assertThat(body.errorSamples().get(1).errorType()).isEqualTo("VALIDATION");
         }
     }
 
@@ -198,8 +223,8 @@ class GlobalExceptionHandlerTest {
     class MaxUploadSizeTest {
 
         @Test
-        @DisplayName("413으로 응답하며 설정된 최대 크기가 메시지에 포함된다")
-        void shouldReturn413WithConfiguredMaxSize() {
+        @DisplayName("413으로 응답하며 예외의 maxUploadSize로 메시지를 구성한다")
+        void shouldReturn413WithMaxSizeFromException() {
             var ex = new MaxUploadSizeExceededException(50 * 1024 * 1024L);
 
             var response = handler.handleMaxUploadSizeExceeded(ex, request);
@@ -211,15 +236,25 @@ class GlobalExceptionHandlerTest {
         }
 
         @Test
-        @DisplayName("다른 설정값일 때도 메시지에 반영된다")
-        void shouldReflectCustomMaxSize() {
-            var customHandler = new GlobalExceptionHandler(100);
+        @DisplayName("다른 maxUploadSize도 MB 변환되어 메시지에 반영된다")
+        void shouldConvertDifferentMaxSizeToMb() {
             var ex = new MaxUploadSizeExceededException(100 * 1024 * 1024L);
 
-            var response = customHandler.handleMaxUploadSizeExceeded(ex, request);
+            var response = handler.handleMaxUploadSizeExceeded(ex, request);
 
             assertThat(response.getBody()).isNotNull();
             assertThat(response.getBody().message()).contains("100MB");
+        }
+
+        @Test
+        @DisplayName("maxUploadSize가 -1이면 크기 정보 없이 메시지를 구성한다")
+        void shouldHandleUnknownMaxSize() {
+            var ex = new MaxUploadSizeExceededException(-1);
+
+            var response = handler.handleMaxUploadSizeExceeded(ex, request);
+
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().message()).isEqualTo("파일 크기 초과");
         }
     }
 


### PR DESCRIPTION
# fix: 파싱 오류 응답 구조화 및 업로드 크기 오류 처리 개선

## Summary
파싱 오류가 과도하게 발생하는 경우 **전용 에러 응답 DTO를 도입**하고,  
파일 업로드 크기 초과 오류 메시지를 **예외 자체 정보 기반으로 정확히 처리**하도록 개선

---

## Context
기존 구조에서는 다음 문제가 존재

- `TooManyParsingErrorsException`이 일반 `ErrorResponse`로 내려가  
  파싱 통계 및 에러 샘플을 클라이언트에 전달할 수 없음
- `MaxUploadSizeExceededException` 메시지가 설정값에 의존해  
  실제 업로드 제한과 불일치 가능성 존재

이로 인해 파싱 실패 원인 분석과 업로드 오류 안내가 불명확했습니다.

---

## Changes

### 1. TooManyParsingErrorsException 전용 응답 DTO 추가
- `GlobalExceptionHandler` 내부에 `ParsingErrorResponse` record 추가
- 기존 `ErrorResponse` + 파싱 통계 필드를 포함한 구조

```json
{
  "timestamp": "...",
  "status": 422,
  "errorCode": "TOO_MANY_PARSING_ERRORS",
  "message": "유효한 로그가 없습니다 (전체 100줄 중 100줄 에러)",
  "path": "/api/analysis",
  "totalLines": 100,
  "errorCount": 100,
  "errorSamples": [
    { "lineNumber": 1, "errorMessage": "잘못된 날짜 형식", "errorType": "PARSING" },
    { "lineNumber": 5, "errorMessage": "필수 필드 누락", "errorType": "VALIDATION" }
  ]
}
```
- 핸들러 반환 타입: ResponseEntity<ParsingErrorResponse>
- 예외의 ParseError → ParseErrorSample(lineNumber, errorMessage, errorType) 변환
- Swagger 문서에 422 응답으로 ParsingErrorResponse 명시

### 2. MaxUploadSizeExceededException 처리 개선

- 설정값 주입(@Value) 및 하드코딩 제거
- e.getMaxUploadSize() 값을 기준으로 메시지 구성
- byte → MB 변환
- -1(알 수 없음)인 경우 크기 정보 없이 기본 메시지 반환
- 테스트 케이스: 50MB / 100MB / -1 모두 검증
---

## Code Convention Checklist
> 본 PR은 프로젝트 코드 컨벤션을 기준으로 검토합니다.  
> 세부 기준은 `docs/CODE_CONVENTION.md`를 따릅니다.

### 1. 객체 생성 & 수명 관리
- [ ] 생성 로직은 생성자 대신 **정적 팩터리 메서드** 또는 **빌더**로 캡슐화했다
- [ ] 매개변수가 많은 객체는 **Builder 패턴**을 사용했다
- [ ] 의존 객체는 **생성자 주입**으로 전달했다
- [ ] 자원 사용 시 **try-with-resources**를 적용했다

### 2. 불변성 & 스레드 안정성
- [ ] 도메인 객체는 **불변(record / @Value)** 으로 설계했다
- [ ] 내부 상태는 외부에서 수정할 수 없도록 보호했다
- [ ] 동시 접근 가능 구조에는 **thread-safe 컬렉션**을 사용했다

### 3. 메서드 계약
- [ ] public 메서드는 **매개변수 유효성 검사**를 수행한다
- [ ] `null` 대신 **Optional 또는 빈 컬렉션**을 반환한다
- [ ] 컬렉션/배열은 **방어적 복사** 또는 불변 래핑을 적용했다
- [ ] 실패 케이스는 **Fail-Fast**로 드러난다

### 4. 계층 분리
- [ ] Domain 레이어는 **외부 의존성(프레임워크/IO)** 이 없다
- [ ] 외부 시스템 연동은 Infrastructure 레이어에 격리했다
- [ ] Application 레이어는 오케스트레이션 책임만 가진다

### 5. 예외 & 로깅
- [ ] 예외 메시지는 **행동 가능한 정보**를 포함한다
- [ ] 성공/실패 로그 레벨을 구분했다
- [ ] 민감 정보는 로그에 남기지 않았다

---

## Behavior Change
<!-- 사용자/클라이언트 관점에서의 동작 변화 -->
- Before: 파싱 오류 상세 정보 미제공
업로드 제한 메시지가 실제 제한과 불일치 가능
- After: 파싱 오류 시 통계 + 샘플을 포함한 구조화된 응답 제공
업로드 크기 초과 메시지가 실제 제한과 정확히 일치

## Test
```bash
./gradlew test
./gradlew build
```

## Risk & Rollback
- Risk: 에러 응답 JSON 구조가 일부 변경됨 (422 케이스 한정)
- Rollback: 단일 PR revert 가능