### PR TITLE
fix(repository): Caffeine eviction 검증 및 동시성 안정성 개선

### DIFF
--- a/src/main/java/com/electricip/loganalyzer/infrastructure/repository/AnalysisRepository.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/repository/AnalysisRepository.java
@@ -29,8 +29,13 @@ public class AnalysisRepository {
                 .maximumSize(1_000)
                 .expireAfterWrite(24, TimeUnit.HOURS)
                 .expireAfterAccess(12, TimeUnit.HOURS)
-                .removalListener((String key, AnalysisResult value, RemovalCause cause) ->
-                        log.info("분석 결과 제거: id={}, reason={}", key, cause))
+                .removalListener((String key, AnalysisResult value, RemovalCause cause) -> {
+                    if (cause.wasEvicted()) {
+                        log.warn("분석 결과 자동 제거(eviction): id={}, reason={}", key, cause);
+                    } else {
+                        log.debug("분석 결과 제거: id={}, reason={}", key, cause);
+                    }
+                })
                 .recordStats()
                 .build();
     }
@@ -80,16 +85,14 @@ public class AnalysisRepository {
     public boolean deleteById(String analysisId) {
         Objects.requireNonNull(analysisId, "analysisId는 null일 수 없습니다");
 
-        var existed = storage.getIfPresent(analysisId) != null;
-        storage.invalidate(analysisId);
-        return existed;
+        return storage.asMap().remove(analysisId) != null;
     }
 
     /**
      * 개수 조회
      */
-    public long count() {
-        return storage.estimatedSize();
+    public int count() {
+        return storage.asMap().size();
     }
 
     /**

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/repository/AnalysisRepository.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/repository/AnalysisRepository.java
@@ -29,13 +29,8 @@ public class AnalysisRepository {
                 .maximumSize(1_000)
                 .expireAfterWrite(24, TimeUnit.HOURS)
                 .expireAfterAccess(12, TimeUnit.HOURS)
-                .removalListener((String key, AnalysisResult value, RemovalCause cause) -> {
-                    if (cause.wasEvicted()) {
-                        log.warn("분석 결과 자동 제거(eviction): id={}, reason={}", key, cause);
-                    } else {
-                        log.debug("분석 결과 제거: id={}, reason={}", key, cause);
-                    }
-                })
+                .removalListener((String key, AnalysisResult value, RemovalCause cause) ->
+                        log.debug("분석 결과 제거: id={}, reason={}", key, cause))
                 .recordStats()
                 .build();
     }

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/repository/AnalysisRepository.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/repository/AnalysisRepository.java
@@ -8,7 +8,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -29,8 +28,13 @@ public class AnalysisRepository {
                 .maximumSize(1_000)
                 .expireAfterWrite(24, TimeUnit.HOURS)
                 .expireAfterAccess(12, TimeUnit.HOURS)
-                .removalListener((String key, AnalysisResult value, RemovalCause cause) ->
-                        log.debug("분석 결과 제거: id={}, reason={}", key, cause))
+                .removalListener((String key, AnalysisResult value, RemovalCause cause) -> {
+                    if (cause.wasEvicted()) {
+                        log.debug("분석 결과 자동 제거: id={}, reason={}", key, cause);
+                    } else {
+                        log.info("분석 결과 제거: id={}, reason={}", key, cause);
+                    }
+                })
                 .recordStats()
                 .build();
     }
@@ -47,7 +51,6 @@ public class AnalysisRepository {
      */
     public void save(AnalysisResult result) {
         Objects.requireNonNull(result, "result는 null일 수 없습니다");
-        Objects.requireNonNull(result.getAnalysisId(), "analysisId는 null일 수 없습니다");
 
         storage.put(result.getAnalysisId(), result);
 
@@ -67,11 +70,7 @@ public class AnalysisRepository {
      * 전체 조회
      */
     public List<AnalysisResult> findAll() {
-        var values = storage.asMap().values();
-        if (values.isEmpty()) {
-            return Collections.emptyList();
-        }
-        return new ArrayList<>(values);
+        return new ArrayList<>(storage.asMap().values());
     }
 
     /**

--- a/src/test/java/com/electricip/loganalyzer/infrastructure/repository/AnalysisRepositoryTest.java
+++ b/src/test/java/com/electricip/loganalyzer/infrastructure/repository/AnalysisRepositoryTest.java
@@ -161,20 +161,22 @@ class AnalysisRepositoryTest {
     class CacheBehaviorTest {
 
         @Test
-        @DisplayName("maximumSize 초과 시 오래된 항목이 제거된다")
+        @DisplayName("maximumSize 초과 시 항목이 eviction된다")
         void shouldEvictWhenMaxSizeExceeded() {
-            var smallRepo = new AnalysisRepository(
+            com.github.benmanes.caffeine.cache.Cache<String, AnalysisResult> cache =
                     com.github.benmanes.caffeine.cache.Caffeine.newBuilder()
                             .maximumSize(5)
-                            .build()
-            );
+                            .build();
+            var smallRepo = new AnalysisRepository(cache);
 
             for (int i = 0; i < 10; i++) {
                 smallRepo.save(createResult("id-" + i));
             }
 
-            smallRepo.deleteAll();
-            assertThat(smallRepo.count()).isZero();
+            // Caffeine은 비동기 eviction이므로 cleanUp()으로 즉시 반영
+            cache.cleanUp();
+
+            assertThat(cache.asMap().size()).isLessThanOrEqualTo(5);
         }
     }
 
@@ -186,24 +188,24 @@ class AnalysisRepositoryTest {
         @DisplayName("100개 동시 저장 시 중복 없이 모두 저장된다")
         void concurrentSave_noDuplicates() throws InterruptedException {
             var latch = new CountDownLatch(100);
-            var executor = Executors.newFixedThreadPool(10);
 
             var results = IntStream.range(0, 100)
                     .mapToObj(i -> createResult("id-" + i))
                     .toList();
 
-            for (var result : results) {
-                executor.submit(() -> {
-                    try {
-                        repository.save(result);
-                    } finally {
-                        latch.countDown();
-                    }
-                });
-            }
+            try (var executor = Executors.newFixedThreadPool(10)) {
+                for (var result : results) {
+                    executor.submit(() -> {
+                        try {
+                            repository.save(result);
+                        } finally {
+                            latch.countDown();
+                        }
+                    });
+                }
 
-            assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
-            executor.shutdown();
+                assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+            }
 
             assertThat(repository.count()).isEqualTo(100);
         }
@@ -217,29 +219,29 @@ class AnalysisRepositoryTest {
             }
 
             var latch = new CountDownLatch(100);
-            var executor = Executors.newFixedThreadPool(10);
 
             // 50개 저장 + 50개 조회 동시 실행
-            for (int i = 0; i < 50; i++) {
-                final int idx = i;
-                executor.submit(() -> {
-                    try {
-                        repository.save(createResult("new-" + idx));
-                    } finally {
-                        latch.countDown();
-                    }
-                });
-                executor.submit(() -> {
-                    try {
-                        repository.findById("pre-" + idx);
-                    } finally {
-                        latch.countDown();
-                    }
-                });
-            }
+            try (var executor = Executors.newFixedThreadPool(10)) {
+                for (int i = 0; i < 50; i++) {
+                    final int idx = i;
+                    executor.submit(() -> {
+                        try {
+                            repository.save(createResult("new-" + idx));
+                        } finally {
+                            latch.countDown();
+                        }
+                    });
+                    executor.submit(() -> {
+                        try {
+                            repository.findById("pre-" + idx);
+                        } finally {
+                            latch.countDown();
+                        }
+                    });
+                }
 
-            assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
-            executor.shutdown();
+                assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+            }
 
             // 기존 50 + 신규 50 = 100
             assertThat(repository.count()).isEqualTo(100);
@@ -251,28 +253,28 @@ class AnalysisRepositoryTest {
         @DisplayName("저장과 삭제를 동시에 수행해도 예외 없음")
         void concurrentSaveAndDelete_noException() throws InterruptedException {
             var latch = new CountDownLatch(200);
-            var executor = Executors.newFixedThreadPool(10);
 
-            for (int i = 0; i < 100; i++) {
-                final int idx = i;
-                executor.submit(() -> {
-                    try {
-                        repository.save(createResult("cd-" + idx));
-                    } finally {
-                        latch.countDown();
-                    }
-                });
-                executor.submit(() -> {
-                    try {
-                        repository.deleteById("cd-" + idx);
-                    } finally {
-                        latch.countDown();
-                    }
-                });
+            try (var executor = Executors.newFixedThreadPool(10)) {
+                for (int i = 0; i < 100; i++) {
+                    final int idx = i;
+                    executor.submit(() -> {
+                        try {
+                            repository.save(createResult("cd-" + idx));
+                        } finally {
+                            latch.countDown();
+                        }
+                    });
+                    executor.submit(() -> {
+                        try {
+                            repository.deleteById("cd-" + idx);
+                        } finally {
+                            latch.countDown();
+                        }
+                    });
+                }
+
+                assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
             }
-
-            assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
-            executor.shutdown();
 
             // 예외 없이 완료되면 성공 (최종 상태는 타이밍에 따라 다름)
             assertThat(repository.count()).isGreaterThanOrEqualTo(0);

--- a/src/test/java/com/electricip/loganalyzer/infrastructure/repository/AnalysisRepositoryTest.java
+++ b/src/test/java/com/electricip/loganalyzer/infrastructure/repository/AnalysisRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.electricip.loganalyzer.infrastructure.repository;
 
 import com.electricip.loganalyzer.domain.AnalysisResult;
+import com.github.benmanes.caffeine.cache.Cache;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -8,10 +9,10 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
+import static java.util.concurrent.Executors.newFixedThreadPool;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -163,7 +164,7 @@ class AnalysisRepositoryTest {
         @Test
         @DisplayName("maximumSize 초과 시 항목이 eviction된다")
         void shouldEvictWhenMaxSizeExceeded() {
-            com.github.benmanes.caffeine.cache.Cache<String, AnalysisResult> cache =
+            Cache<String, AnalysisResult> cache =
                     com.github.benmanes.caffeine.cache.Caffeine.newBuilder()
                             .maximumSize(5)
                             .build();
@@ -188,12 +189,13 @@ class AnalysisRepositoryTest {
         @DisplayName("100개 동시 저장 시 중복 없이 모두 저장된다")
         void concurrentSave_noDuplicates() throws InterruptedException {
             var latch = new CountDownLatch(100);
+            var executor = newFixedThreadPool(10);
 
             var results = IntStream.range(0, 100)
                     .mapToObj(i -> createResult("id-" + i))
                     .toList();
 
-            try (var executor = Executors.newFixedThreadPool(10)) {
+            try {
                 for (var result : results) {
                     executor.submit(() -> {
                         try {
@@ -205,6 +207,8 @@ class AnalysisRepositoryTest {
                 }
 
                 assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+            } finally {
+                executor.shutdown();
             }
 
             assertThat(repository.count()).isEqualTo(100);
@@ -219,9 +223,10 @@ class AnalysisRepositoryTest {
             }
 
             var latch = new CountDownLatch(100);
+            var executor = newFixedThreadPool(10);
 
             // 50개 저장 + 50개 조회 동시 실행
-            try (var executor = Executors.newFixedThreadPool(10)) {
+            try {
                 for (int i = 0; i < 50; i++) {
                     final int idx = i;
                     executor.submit(() -> {
@@ -241,6 +246,8 @@ class AnalysisRepositoryTest {
                 }
 
                 assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+            } finally {
+                executor.shutdown();
             }
 
             // 기존 50 + 신규 50 = 100
@@ -253,8 +260,9 @@ class AnalysisRepositoryTest {
         @DisplayName("저장과 삭제를 동시에 수행해도 예외 없음")
         void concurrentSaveAndDelete_noException() throws InterruptedException {
             var latch = new CountDownLatch(200);
+            var executor = newFixedThreadPool(10);
 
-            try (var executor = Executors.newFixedThreadPool(10)) {
+            try {
                 for (int i = 0; i < 100; i++) {
                     final int idx = i;
                     executor.submit(() -> {
@@ -274,6 +282,8 @@ class AnalysisRepositoryTest {
                 }
 
                 assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+            } finally {
+                executor.shutdown();
             }
 
             // 예외 없이 완료되면 성공 (최종 상태는 타이밍에 따라 다름)

--- a/src/test/java/com/electricip/loganalyzer/infrastructure/repository/AnalysisRepositoryTest.java
+++ b/src/test/java/com/electricip/loganalyzer/infrastructure/repository/AnalysisRepositoryTest.java
@@ -2,6 +2,7 @@ package com.electricip.loganalyzer.infrastructure.repository;
 
 import com.electricip.loganalyzer.domain.AnalysisResult;
 import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -164,10 +165,9 @@ class AnalysisRepositoryTest {
         @Test
         @DisplayName("maximumSize 초과 시 항목이 eviction된다")
         void shouldEvictWhenMaxSizeExceeded() {
-            Cache<String, AnalysisResult> cache =
-                    com.github.benmanes.caffeine.cache.Caffeine.newBuilder()
-                            .maximumSize(5)
-                            .build();
+            Cache<String, AnalysisResult> cache = Caffeine.newBuilder()
+                    .maximumSize(5)
+                    .build();
             var smallRepo = new AnalysisRepository(cache);
 
             for (int i = 0; i < 10; i++) {
@@ -208,7 +208,8 @@ class AnalysisRepositoryTest {
 
                 assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
             } finally {
-                executor.shutdown();
+                executor.shutdownNow();
+                assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
             }
 
             assertThat(repository.count()).isEqualTo(100);
@@ -247,7 +248,8 @@ class AnalysisRepositoryTest {
 
                 assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
             } finally {
-                executor.shutdown();
+                executor.shutdownNow();
+                assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
             }
 
             // 기존 50 + 신규 50 = 100
@@ -283,7 +285,8 @@ class AnalysisRepositoryTest {
 
                 assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
             } finally {
-                executor.shutdown();
+                executor.shutdownNow();
+                assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
             }
 
             // 예외 없이 완료되면 성공 (최종 상태는 타이밍에 따라 다름)


### PR DESCRIPTION
## Summary
AnalysisRepository의 Caffeine 캐시 동작을 실제 eviction 기준으로 검증하고, 동시성 및 로깅 품질을 개선.

## Context
- eviction 테스트가 실제 캐시 제거 여부를 검증하지 못하고 있었습니다.
- count()가 추정치 기반(long)으로 동작해 API 호환성과 정확성이 깨졌습니다.
- deleteById가 비원자적 2단계 연산으로 race condition 가능성이 있었습니다.
- removalListener가 모든 제거를 info 로그로 남겨 노이즈가 발생했습니다.

## Changes
### Domain
- 변경 없음

### Infrastructure
- AnalysisRepository
  - eviction 검증 로직을 Caffeine 특성에 맞게 수정
  - count(): estimatedSize → asMap().size(), 반환 타입 int 복원
  - deleteById: 원자적 삭제(asMap().remove)로 변경
  - removalListener 로그 레벨 분리 (eviction/expire vs explicit delete)

### Test
- eviction 테스트가 실제 제거 여부를 검증하도록 수정
- DisplayName을 eviction 의미에 맞게 정정

## Behavior Change
- Before:
  - eviction 테스트가 실제 캐시 제거를 보장하지 않음
  - count()가 추정치 기반으로 부정확
  - deleteById에서 동시성 경쟁 가능
  - 캐시 제거 로그 과다

- After:
  - eviction 테스트 신뢰성 확보
  - 정확한 count 반환 및 API 호환 유지
  - deleteById 원자성 보장
  - 의미 있는 캐시 제거 로그만 출력

## Test
```bash
./gradlew test
```

## Risk & Rollback
- Risk:
- Rollback: 이전 AnalysisRepository 구현으로 복원