### PR TITLE
refactor(infra): IpInfoClient 안정성·동시성·캐시 처리 전반 개선

### DIFF
--- a/src/main/java/com/electricip/loganalyzer/application/AnalysisService.java
+++ b/src/main/java/com/electricip/loganalyzer/application/AnalysisService.java
@@ -148,6 +148,7 @@ public class AnalysisService {
         
         return topIps.stream()
                 .map(AnalysisResult.TopItem::item)
+                .distinct()
                 .collect(Collectors.toMap(
                         ip -> ip,
                         ip -> {

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoCircuitBreaker.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoCircuitBreaker.java
@@ -26,15 +26,19 @@ public class IpInfoCircuitBreaker {
      * — 타임아웃 이후면 half-open (재시도 허용, 카운터 리셋)
      */
     public boolean isOpen() {
-        if (failureCount.get() < FAILURE_THRESHOLD) {
+        int currentFailures = failureCount.get();
+        if (currentFailures < FAILURE_THRESHOLD) {
             return false;
         }
 
-        // 타임아웃 지났으면 half-open → 카운터 리셋
+        // 타임아웃 지났으면 half-open → CAS로 단일 스레드만 리셋
         if (System.currentTimeMillis() - lastFailureTime.get() > TIMEOUT_MS) {
-            log.info("Circuit Breaker half-open: 재시도 허용");
-            failureCount.set(0);
-            return false;
+            if (failureCount.compareAndSet(currentFailures, 0)) {
+                log.info("Circuit Breaker half-open: 재시도 허용");
+                return false;
+            }
+            // 다른 스레드가 이미 리셋 → 현재 상태로 판단
+            return failureCount.get() >= FAILURE_THRESHOLD;
         }
 
         return true;
@@ -51,8 +55,8 @@ public class IpInfoCircuitBreaker {
      * 실패 기록 — 카운터 증가 + 시각 갱신
      */
     public void recordFailure() {
-        failureCount.incrementAndGet();
         lastFailureTime.set(System.currentTimeMillis());
+        failureCount.incrementAndGet();
     }
 
     /**

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoClient.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoClient.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.Objects;
 
@@ -39,13 +40,12 @@ public class IpInfoClient {
      * @return IP 정보 (null 반환하지 않음)
      * @throws NullPointerException ip가 null인 경우
      */
-    @Cacheable(value = "ipInfoCache", key = "#ip", unless = "#result == null")
+    @Cacheable(value = "ipInfoCache", key = "#ip", unless = "#result == null || !#result.isValid()")
     public IpInfo getIpInfo(String ip) {
         Objects.requireNonNull(ip, "ip는 null일 수 없습니다");
 
         if (ip.isBlank()) {
-            log.warn("빈 IP 주소");
-            return IpInfo.unknown(ip);
+            throw new IllegalArgumentException("IP는 비어있을 수 없습니다");
         }
 
         // Circuit Open → fallback
@@ -61,10 +61,12 @@ public class IpInfoClient {
      * 재시도 로직 (exponential backoff)
      */
     private IpInfo callWithRetry(String ip) {
-        for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        for (int attempt = 1; ; attempt++) {
             try {
                 var result = callApi(ip);
-                circuitBreaker.recordSuccess();
+                if (result.isValid()) {
+                    circuitBreaker.recordSuccess();
+                }
                 return result;
 
             } catch (RateLimitExceededException e) {
@@ -78,9 +80,8 @@ public class IpInfoClient {
                 return IpInfo.unknown(ip);
 
             } catch (Exception e) {
-                circuitBreaker.recordFailure();
-
-                if (attempt == MAX_ATTEMPTS) {
+                if (attempt >= MAX_ATTEMPTS) {
+                    circuitBreaker.recordFailure();
                     log.error("ipinfo API 최종 실패: ip={}, attempts={}", ip, MAX_ATTEMPTS, e);
                     return IpInfo.unknown(ip);
                 }
@@ -88,11 +89,13 @@ public class IpInfoClient {
                 log.warn("ipinfo API 재시도: ip={}, attempt={}/{}, error={}",
                         ip, attempt, MAX_ATTEMPTS, e.getMessage());
 
-                sleep(BACKOFF_MS * attempt);
+                if (sleep(BACKOFF_MS * attempt)) {
+                    log.warn("ipinfo API 재시도 중단 (인터럽트): ip={}", ip);
+                    circuitBreaker.recordFailure();
+                    return IpInfo.unknown(ip);
+                }
             }
         }
-
-        return IpInfo.unknown(ip);
     }
 
     /**
@@ -105,8 +108,9 @@ public class IpInfoClient {
         if (response != null) {
             log.debug("IP 정보 조회 성공: ip={}, country={}", ip, response.country);
 
+            var resolvedIp = (response.ip != null && !response.ip.isBlank()) ? response.ip : ip;
             return IpInfo.of(
-                    response.ip,
+                    resolvedIp,
                     response.country,
                     response.region,
                     response.city,
@@ -121,17 +125,23 @@ public class IpInfoClient {
      * API URL 구성
      */
     private String buildUrl(String ip) {
+        var builder = UriComponentsBuilder.fromHttpUrl(baseUrl)
+                .pathSegment(ip, "json");
+
         if (token != null && !token.isBlank()) {
-            return String.format("%s/%s?token=%s", baseUrl, ip, token);
+            builder.queryParam("token", token);
         }
-        return String.format("%s/%s/json", baseUrl, ip);
+
+        return builder.build().toUriString();
     }
 
-    private void sleep(long ms) {
+    private boolean sleep(long ms) {
         try {
             Thread.sleep(ms);
+            return false;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            return true;
         }
     }
 

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoClient.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoClient.java
@@ -38,7 +38,8 @@ public class IpInfoClient {
      *
      * @param ip IP 주소
      * @return IP 정보 (null 반환하지 않음)
-     * @throws NullPointerException ip가 null인 경우
+     * @throws NullPointerException     ip가 null인 경우
+     * @throws IllegalArgumentException ip가 빈 문자열 또는 공백만 포함하는 경우
      */
     @Cacheable(value = "ipInfoCache", key = "#ip", unless = "#result == null || !#result.isValid()")
     public IpInfo getIpInfo(String ip) {
@@ -66,8 +67,23 @@ public class IpInfoClient {
                 var result = callApi(ip);
                 if (result.isValid()) {
                     circuitBreaker.recordSuccess();
+                    return result;
                 }
-                return result;
+
+                // invalid 결과 (null 응답 등) — 재시도 대상
+                if (attempt >= MAX_ATTEMPTS) {
+                    circuitBreaker.recordFailure();
+                    log.warn("ipinfo API 유효하지 않은 응답: ip={}, attempts={}", ip, MAX_ATTEMPTS);
+                    return result;
+                }
+                log.warn("ipinfo API 유효하지 않은 응답, 재시도: ip={}, attempt={}/{}",
+                        ip, attempt, MAX_ATTEMPTS);
+
+                if (sleep(BACKOFF_MS * attempt)) {
+                    log.warn("ipinfo API 재시도 중단 (인터럽트): ip={}", ip);
+                    circuitBreaker.recordFailure();
+                    return result;
+                }
 
             } catch (RateLimitExceededException e) {
                 log.error("ipinfo rate limit 초과: ip={}", ip);

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoErrorHandler.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoErrorHandler.java
@@ -1,6 +1,5 @@
 package com.electricip.loganalyzer.infrastructure.client;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.web.client.ResponseErrorHandler;
 
@@ -21,10 +20,10 @@ public class IpInfoErrorHandler implements ResponseErrorHandler {
     public void handleError(ClientHttpResponse response) throws IOException {
         var status = response.getStatusCode();
 
-        if (status == HttpStatus.TOO_MANY_REQUESTS) {
+        if (status.value() == 429) {
             throw new RateLimitExceededException("ipinfo API rate limit 초과");
         }
-        if (status == HttpStatus.UNAUTHORIZED || status == HttpStatus.FORBIDDEN) {
+        if (status.value() == 401 || status.value() == 403) {
             throw new IpInfoAuthException("ipinfo API 인증 실패");
         }
         if (status.is5xxServerError()) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,8 +13,6 @@ spring:
       
   cache:
     type: caffeine
-    caffeine:
-      spec: maximumSize=10000,expireAfterWrite=1h
 
 # ipinfo API
 ipinfo:

--- a/src/test/java/com/electricip/loganalyzer/infrastructure/client/IpInfoClientTest.java
+++ b/src/test/java/com/electricip/loganalyzer/infrastructure/client/IpInfoClientTest.java
@@ -134,6 +134,41 @@ class IpInfoClientTest {
             // 3번 호출 (최초 + 2회 재시도)
             verify(restTemplate, times(3)).getForObject(anyString(), any(Class.class));
         }
+
+        @Test
+        @DisplayName("null 응답은 MAX_ATTEMPTS까지 재시도하고 실패를 기록한다")
+        void shouldRetryAndRecordFailureOnNullResponse() {
+            when(restTemplate.getForObject(anyString(), any(Class.class)))
+                    .thenReturn(null);
+
+            var result = client.getIpInfo("1.2.3.4");
+
+            assertThat(result.isValid()).isFalse();
+            // 3번 호출 (최초 + 2회 재시도)
+            verify(restTemplate, times(3)).getForObject(anyString(), any(Class.class));
+            // 최종 실패 시 1회 기록
+            assertThat(circuitBreaker.getFailureCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("null 응답 반복 시 Circuit Breaker가 열린다")
+        void shouldOpenCircuitOnRepeatedNullResponses() {
+            when(restTemplate.getForObject(anyString(), any(Class.class)))
+                    .thenReturn(null);
+
+            // FAILURE_THRESHOLD(5)회 호출 → 각각 1회 failure 기록
+            for (int i = 0; i < IpInfoCircuitBreaker.FAILURE_THRESHOLD; i++) {
+                client.getIpInfo("10.0.0." + i);
+            }
+
+            assertThat(circuitBreaker.isOpen()).isTrue();
+
+            // 이후 호출은 API 없이 fallback 반환
+            reset(restTemplate);
+            var result = client.getIpInfo("10.0.0.99");
+            assertThat(result.isValid()).isFalse();
+            verifyNoInteractions(restTemplate);
+        }
     }
 
     @Nested

--- a/src/test/java/com/electricip/loganalyzer/infrastructure/client/IpInfoClientTest.java
+++ b/src/test/java/com/electricip/loganalyzer/infrastructure/client/IpInfoClientTest.java
@@ -87,8 +87,8 @@ class IpInfoClientTest {
 
             client.getIpInfo("1.2.3.4");
 
-            // MAX_ATTEMPTS(3)만큼 실패 기록
-            assertThat(circuitBreaker.getFailureCount()).isEqualTo(3);
+            // 최종 실패 시 1회만 기록
+            assertThat(circuitBreaker.getFailureCount()).isEqualTo(1);
         }
     }
 


### PR DESCRIPTION
## Summary
<!-- 이 PR이 무엇을 변경하는지 한 줄 요약 -->
ipinfo API 연동의 안정성과 서비스 보호를 강화
무한 대기, 무차별 재시도, 장애 전파 위험을 제거하고 timeout / retry / circuit breaker / cache 정책을 적용

## Context
<!-- 왜 이 변경이 필요한지 / 배경 -->
- Issue: 기존 ipinfo 연동은 다음과 같은 운영 리스크 존재
  - API 지연 시 무한 대기 → 스레드 고갈 가능
  - 일시적 네트워크 오류에도 즉시 실패
  - 장애 상태에서도 지속적인 외부 호출
  - Rate limit / 인증 오류 / 서버 오류 구분 불가
  - 캐시 무제한 증가로 메모리 압박 가능
- Background: 본 PR은 의존성 추가 없이(Resilience4j 등 미사용)
현재 코드베이스에 맞는 최소한의 방어 장치를 적용하는 것을 목표

## Changes
<!-- 변경 사항을 계층별로 간결하게 -->
- Infrastructure:
  - RestTemplate
        - connect timeout(3s), read timeout(5s) 설정
        - IpInfoErrorHandler 추가 → HTTP 상태별 예외 분류
  - IpInfoClient
        - 재시도(최대 3회) + exponential backoff
        - 에러 타입별 retry 여부 분리
        -  Circuit Breaker 연동 (fail-fast + 자동 회복)
        -  실패 결과 캐싱 방지
        -  URL 인코딩 및 null 응답 방어
  - Circuit Breaker
        - thread-safe 구현
        - threshold=5, timeout=60s, half-open recovery
        - 동시성 테스트로 race condition 검증
  - Cache
        - Caffeine 기반 LRU + TTL 적용
        - expireAfterWrite(24h), expireAfterAccess(12h)
        - eviction logging 추가

---

## Non-goals / Design Notes

GlobalExceptionHandler의 IpInfoException 핸들러는
현재 흐름에서는 도달하지 않지만,
향후 IpInfoClient를 직접 사용하는 endpoint 대비용으로 유지했습니다.

ipinfo 전용 RestTemplate 분리는
현재 단일 사용처이므로 과설계 방지 차원에서 보류했습니다.
추가 HTTP client 도입 시 @Qualifier로 분리 예정입니다.

Cache의 write/access 이중 TTL은
Caffeine 설계상 의도된 동작이며,
더 빠른 조건으로 eviction 되도록 설계되었습니다.

---

## Code Convention Checklist
> 본 PR은 프로젝트 코드 컨벤션을 기준으로 검토합니다.  
> 세부 기준은 `docs/CODE_CONVENTION.md`를 따릅니다.

### 1. 객체 생성 & 수명 관리
- [ ] 생성 로직은 생성자 대신 **정적 팩터리 메서드** 또는 **빌더**로 캡슐화했다
- [ ] 매개변수가 많은 객체는 **Builder 패턴**을 사용했다
- [ ] 의존 객체는 **생성자 주입**으로 전달했다
- [ ] 자원 사용 시 **try-with-resources**를 적용했다

### 2. 불변성 & 스레드 안정성
- [ ] 도메인 객체는 **불변(record / @Value)** 으로 설계했다
- [ ] 내부 상태는 외부에서 수정할 수 없도록 보호했다
- [ ] 동시 접근 가능 구조에는 **thread-safe 컬렉션**을 사용했다

### 3. 메서드 계약
- [ ] public 메서드는 **매개변수 유효성 검사**를 수행한다
- [ ] `null` 대신 **Optional 또는 빈 컬렉션**을 반환한다
- [ ] 컬렉션/배열은 **방어적 복사** 또는 불변 래핑을 적용했다
- [ ] 실패 케이스는 **Fail-Fast**로 드러난다

### 4. 계층 분리
- [ ] Domain 레이어는 **외부 의존성(프레임워크/IO)** 이 없다
- [ ] 외부 시스템 연동은 Infrastructure 레이어에 격리했다
- [ ] Application 레이어는 오케스트레이션 책임만 가진다

### 5. 예외 & 로깅
- [ ] 예외 메시지는 **행동 가능한 정보**를 포함한다
- [ ] 성공/실패 로그 레벨을 구분했다
- [ ] 민감 정보는 로그에 남기지 않았다

---

## Behavior Change
<!-- 사용자/클라이언트 관점에서의 동작 변화 -->
- Before: ipinfo 장애 시 무한 대기 또는 즉시 실패
장애 중에도 반복 호출
메모리 사용량 무제한 증가 가능
- After: 최대 5초 내 응답 보장
일시적 오류는 자동 복구
장애 시 fast-fail + fallback
캐시 크기 및 수명 제한

## Test
```bash
./gradlew test
./gradlew build
```

## Risk & Rollback
- Risk: retry/circuit breaker 로직 추가로 코드 경로 증가
- Rollback: IpInfoClient를 이전 단순 호출 방식으로 되돌리면 됨