### PR TITLE
perf(application): IP enrichment 병렬 처리 (virtual threads) + timeout

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,9 @@ group = "com.electricip"
 version = "1.0.0"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,5 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+
 rootProject.name = "log-analyzer"

--- a/src/main/java/com/electricip/loganalyzer/application/AnalysisService.java
+++ b/src/main/java/com/electricip/loganalyzer/application/AnalysisService.java
@@ -18,6 +18,11 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 /**
@@ -33,6 +38,7 @@ public class AnalysisService {
     private final AnalysisRepository repository;
     private final StatisticsCalculator statisticsCalculator;
     private final LogAnalysisProperties properties;
+    private final Executor ipEnrichmentExecutor;
     
     /**
      * 로그 분석
@@ -137,26 +143,59 @@ public class AnalysisService {
     }
     
     /**
-     * IP 정보 enrichment
+     * IP 정보 병렬 enrichment (CompletableFuture + 전용 스레드 풀)
      */
     private Map<String, IpInfo> enrichIpInfo(List<AnalysisResult.TopItem> topIps) {
         if (topIps.isEmpty()) {
             return Collections.emptyMap();
         }
-        
-        return topIps.stream()
+
+        var ips = topIps.stream()
                 .map(AnalysisResult.TopItem::item)
+                .filter(ip -> ip != null && !ip.isBlank())
                 .distinct()
+                .toList();
+
+        if (ips.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        var futures = ips.stream()
                 .collect(Collectors.toMap(
                         ip -> ip,
-                        ip -> {
-                            try {
-                                return ipInfoClient.getIpInfo(ip);
-                            } catch (Exception e) {
-                                log.warn("IP 정보 조회 실패: ip={}", ip);
-                                return IpInfo.unknown(ip);
-                            }
-                        }
+                        ip -> CompletableFuture.supplyAsync(
+                                () -> fetchIpInfoSafely(ip),
+                                ipEnrichmentExecutor
+                        )
                 ));
+
+        var allOf = CompletableFuture.allOf(futures.values().toArray(new CompletableFuture[0]));
+        try {
+            allOf.get(properties.ipEnrichmentTimeoutSeconds(), TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            log.warn("IP enrichment 타임아웃 ({}초), 완료된 결과만 반환",
+                    properties.ipEnrichmentTimeoutSeconds());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("IP enrichment 인터럽트");
+        } catch (ExecutionException e) {
+            log.error("IP enrichment 실패", e.getCause());
+        }
+
+        return futures.entrySet().stream()
+                .filter(entry -> entry.getValue().isDone() && !entry.getValue().isCompletedExceptionally())
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> entry.getValue().join()
+                ));
+    }
+
+    private IpInfo fetchIpInfoSafely(String ip) {
+        try {
+            return ipInfoClient.getIpInfo(ip);
+        } catch (Exception e) {
+            log.warn("IP 정보 조회 실패: ip={}, error={}", ip, e.getMessage());
+            return IpInfo.unknown(ip);
+        }
     }
 }

--- a/src/main/java/com/electricip/loganalyzer/application/AnalysisService.java
+++ b/src/main/java/com/electricip/loganalyzer/application/AnalysisService.java
@@ -19,10 +19,8 @@ import org.springframework.web.multipart.MultipartFile;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 /**
@@ -160,26 +158,21 @@ public class AnalysisService {
             return Collections.emptyMap();
         }
 
+        var timeout = properties.ipEnrichmentTimeoutSeconds();
+
         var futures = ips.stream()
                 .collect(Collectors.toMap(
                         ip -> ip,
                         ip -> CompletableFuture.supplyAsync(
                                 () -> fetchIpInfoSafely(ip),
                                 ipEnrichmentExecutor
-                        )
+                        ).completeOnTimeout(IpInfo.unknown(ip), timeout, TimeUnit.SECONDS)
                 ));
 
-        var allOf = CompletableFuture.allOf(futures.values().toArray(new CompletableFuture[0]));
         try {
-            allOf.get(properties.ipEnrichmentTimeoutSeconds(), TimeUnit.SECONDS);
-        } catch (TimeoutException e) {
-            log.warn("IP enrichment 타임아웃 ({}초), 완료된 결과만 반환",
-                    properties.ipEnrichmentTimeoutSeconds());
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.warn("IP enrichment 인터럽트");
-        } catch (ExecutionException e) {
-            log.error("IP enrichment 실패", e.getCause());
+            CompletableFuture.allOf(futures.values().toArray(new CompletableFuture[0])).join();
+        } catch (Exception e) {
+            log.warn("IP enrichment 중 예외 발생, 완료된 결과만 반환", e);
         }
 
         return futures.entrySet().stream()

--- a/src/main/java/com/electricip/loganalyzer/config/AsyncConfig.java
+++ b/src/main/java/com/electricip/loganalyzer/config/AsyncConfig.java
@@ -1,0 +1,19 @@
+package com.electricip.loganalyzer.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+/**
+ * 비동기 처리 설정
+ */
+@Configuration
+public class AsyncConfig {
+
+    @Bean("ipEnrichmentExecutor")
+    public Executor ipEnrichmentExecutor() {
+        return Executors.newVirtualThreadPerTaskExecutor();
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/config/LogAnalysisProperties.java
+++ b/src/main/java/com/electricip/loganalyzer/config/LogAnalysisProperties.java
@@ -6,13 +6,15 @@ import org.springframework.boot.context.properties.bind.DefaultValue;
 /**
  * 로그 분석 설정 프로퍼티
  *
- * @param maxFileLines  CSV 파일 최대 파싱 라인 수
- * @param topNResults   통계 상위 N개 결과 수
- * @param maxFileSizeMb 업로드 허용 최대 파일 크기 (MB)
+ * @param maxFileLines              CSV 파일 최대 파싱 라인 수
+ * @param topNResults               통계 상위 N개 결과 수
+ * @param maxFileSizeMb             업로드 허용 최대 파일 크기 (MB)
+ * @param ipEnrichmentTimeoutSeconds IP enrichment 전체 타임아웃 (초)
  */
 @ConfigurationProperties(prefix = "log-analysis")
 public record LogAnalysisProperties(
         @DefaultValue("200000") int maxFileLines,
         @DefaultValue("10") int topNResults,
-        @DefaultValue("50") int maxFileSizeMb
+        @DefaultValue("50") int maxFileSizeMb,
+        @DefaultValue("5") int ipEnrichmentTimeoutSeconds
 ) {}

--- a/src/main/java/com/electricip/loganalyzer/config/WebConfig.java
+++ b/src/main/java/com/electricip/loganalyzer/config/WebConfig.java
@@ -6,6 +6,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.Duration;
+
 /**
  * Web 설정
  */
@@ -20,8 +22,8 @@ public class WebConfig {
     @Bean
     public RestTemplate restTemplate() {
         var factory = new SimpleClientHttpRequestFactory();
-        factory.setConnectTimeout(3_000);
-        factory.setReadTimeout(5_000);
+        factory.setConnectTimeout(Duration.ofSeconds(3));
+        factory.setReadTimeout(Duration.ofSeconds(5));
 
         var restTemplate = new RestTemplate(factory);
         restTemplate.setErrorHandler(new IpInfoErrorHandler());

--- a/src/main/java/com/electricip/loganalyzer/domain/AccessLog.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/AccessLog.java
@@ -1,7 +1,6 @@
 package com.electricip.loganalyzer.domain;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
 
 /**
  * 접속 로그 도메인 모델
@@ -39,6 +38,7 @@ public record AccessLog(
      */
     public String statusCategory() {
         if (httpStatus == null) return "Unknown";
+        if (httpStatus >= 100 && httpStatus < 200) return "1xx";
         if (httpStatus >= 200 && httpStatus < 300) return "2xx";
         if (httpStatus >= 300 && httpStatus < 400) return "3xx";
         if (httpStatus >= 400 && httpStatus < 500) return "4xx";

--- a/src/main/java/com/electricip/loganalyzer/domain/ParseStatistics.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/ParseStatistics.java
@@ -29,19 +29,12 @@ public record ParseStatistics(
         if (errorCount < 0) {
             throw new IllegalArgumentException("errorCount는 음수일 수 없습니다");
         }
+        if (successCount + errorCount > totalLines) {
+            throw new IllegalArgumentException(
+                    "successCount + errorCount는 totalLines를 초과할 수 없습니다");
+        }
         errorsByType = (errorsByType != null) ? Map.copyOf(errorsByType) : Map.of();
         errorSamples = (errorSamples != null) ? List.copyOf(errorSamples) : List.of();
-    }
-
-    /**
-     * 방어적 복사 — 내부 컬렉션 노출 방지
-     */
-    public Map<String, Integer> errorsByType() {
-        return Map.copyOf(errorsByType);
-    }
-
-    public List<ParseError> errorSamples() {
-        return List.copyOf(errorSamples);
     }
 
     /**

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/repository/AnalysisRepository.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/repository/AnalysisRepository.java
@@ -54,13 +54,12 @@ public class AnalysisRepository {
     public void save(AnalysisResult result) {
         Objects.requireNonNull(result, "result는 null일 수 없습니다");
 
-        if (storage.getIfPresent(result.getAnalysisId()) != null) {
+        var existing = storage.asMap().putIfAbsent(result.getAnalysisId(), result);
+        if (existing != null) {
             throw new DuplicateAnalysisIdException(result.getAnalysisId());
         }
 
-        storage.put(result.getAnalysisId(), result);
-
-        log.debug("저장 완료: id={}, cacheSize={}", result.getAnalysisId(), storage.estimatedSize());
+        log.debug("저장 완료: id={}, cacheSize={}", result.getAnalysisId(), storage.asMap().size());
     }
 
     /**
@@ -92,7 +91,7 @@ public class AnalysisRepository {
      * 개수 조회
      */
     public long count() {
-        return storage.estimatedSize();
+        return storage.asMap().size();
     }
 
     /**

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/repository/AnalysisRepository.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/repository/AnalysisRepository.java
@@ -1,6 +1,7 @@
 package com.electricip.loganalyzer.infrastructure.repository;
 
 import com.electricip.loganalyzer.domain.AnalysisResult;
+import com.electricip.loganalyzer.domain.exception.DuplicateAnalysisIdException;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalCause;
@@ -47,9 +48,15 @@ public class AnalysisRepository {
 
     /**
      * 저장
+     *
+     * @throws DuplicateAnalysisIdException 동일 ID가 이미 존재하는 경우
      */
     public void save(AnalysisResult result) {
         Objects.requireNonNull(result, "result는 null일 수 없습니다");
+
+        if (storage.getIfPresent(result.getAnalysisId()) != null) {
+            throw new DuplicateAnalysisIdException(result.getAnalysisId());
+        }
 
         storage.put(result.getAnalysisId(), result);
 
@@ -84,8 +91,8 @@ public class AnalysisRepository {
     /**
      * 개수 조회
      */
-    public int count() {
-        return storage.asMap().size();
+    public long count() {
+        return storage.estimatedSize();
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,7 @@ log-analysis:
   max-file-lines: 200000
   max-file-size-mb: 50
   top-n-results: 10
+  ip-enrichment-timeout-seconds: 5
 
 # 로깅
 logging:

--- a/src/test/java/com/electricip/loganalyzer/ConfigurationPropertiesBindingTest.java
+++ b/src/test/java/com/electricip/loganalyzer/ConfigurationPropertiesBindingTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         "log-analysis.max-file-lines=99999",
         "log-analysis.top-n-results=7",
         "log-analysis.max-file-size-mb=25",
+        "log-analysis.ip-enrichment-timeout-seconds=3",
         "ipinfo.base-url=https://test.ipinfo.io",
         "ipinfo.token=test-token"
 })
@@ -35,6 +36,7 @@ class ConfigurationPropertiesBindingTest {
         assertThat(logAnalysisProperties.maxFileLines()).isEqualTo(99_999);
         assertThat(logAnalysisProperties.topNResults()).isEqualTo(7);
         assertThat(logAnalysisProperties.maxFileSizeMb()).isEqualTo(25);
+        assertThat(logAnalysisProperties.ipEnrichmentTimeoutSeconds()).isEqualTo(3);
     }
 
     @Test

--- a/src/test/java/com/electricip/loganalyzer/application/AnalysisServiceTest.java
+++ b/src/test/java/com/electricip/loganalyzer/application/AnalysisServiceTest.java
@@ -1,0 +1,229 @@
+package com.electricip.loganalyzer.application;
+
+import com.electricip.loganalyzer.config.LogAnalysisProperties;
+import com.electricip.loganalyzer.domain.*;
+import com.electricip.loganalyzer.infrastructure.client.IpInfoClient;
+import com.electricip.loganalyzer.infrastructure.parser.CsvLogParser;
+import com.electricip.loganalyzer.infrastructure.repository.AnalysisRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AnalysisServiceTest {
+
+    @Mock private CsvLogParser logParser;
+    @Mock private IpInfoClient ipInfoClient;
+    @Mock private AnalysisRepository repository;
+    @Mock private StatisticsCalculator statisticsCalculator;
+
+    private AnalysisService service;
+
+    @BeforeEach
+    void setUp() {
+        var properties = new LogAnalysisProperties(200_000, 10, 50, 5);
+        var executor = Executors.newVirtualThreadPerTaskExecutor();
+        service = new AnalysisService(
+                logParser, ipInfoClient, repository,
+                statisticsCalculator, properties, executor);
+    }
+
+    private CsvLogParser.ParseResult createParseResult(int logCount) {
+        var logs = Collections.nCopies(logCount, new AccessLog(
+                null, "1.1.1.1", "GET", "/api/test", "Mozilla",
+                200, "HTTP/1.1", 100L, 200L, 0.5, "TLSv1.2", "/api/test"));
+        return new CsvLogParser.ParseResult(logs,
+                new ParseStatistics(logCount, logCount, 0, Map.of(), List.of()));
+    }
+
+    private AnalysisResult.Statistics createStats(List<AnalysisResult.TopItem> topIps) {
+        return AnalysisResult.Statistics.builder()
+                .totalRequests(100)
+                .successCount(90)
+                .redirectCount(5)
+                .clientErrorCount(3)
+                .serverErrorCount(2)
+                .topPaths(List.of())
+                .topStatusCodes(List.of())
+                .topIps(topIps)
+                .methodStats(Map.of())
+                .avgResponseTime(0.5)
+                .avgSentBytes(200.0)
+                .totalTraffic(20000)
+                .build();
+    }
+
+    private MultipartFile mockFile() throws Exception {
+        var file = mock(MultipartFile.class);
+        when(file.isEmpty()).thenReturn(false);
+        when(file.getSize()).thenReturn(100L);
+        when(file.getOriginalFilename()).thenReturn("test.csv");
+        when(file.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[0]));
+        return file;
+    }
+
+    @Nested
+    @DisplayName("IP enrichment 병렬 처리")
+    class IpEnrichmentTest {
+
+        @Test
+        @DisplayName("여러 IP가 병렬로 조회되어 결과에 포함된다")
+        void shouldEnrichMultipleIpsInParallel() throws Exception {
+            var file = mockFile();
+            var topIps = List.of(
+                    new AnalysisResult.TopItem("1.1.1.1", 100),
+                    new AnalysisResult.TopItem("2.2.2.2", 50),
+                    new AnalysisResult.TopItem("3.3.3.3", 25));
+
+            when(logParser.parse(any())).thenReturn(createParseResult(3));
+            when(statisticsCalculator.calculate(any())).thenReturn(createStats(topIps));
+            when(ipInfoClient.getIpInfo(anyString())).thenAnswer(inv -> {
+                String ip = inv.getArgument(0);
+                return IpInfo.of(ip, "KR", "Seoul", "Seoul", "ISP");
+            });
+
+            var result = service.analyze(file);
+
+            assertThat(result.getIpDetails()).hasSize(3);
+            assertThat(result.getIpDetails()).containsKeys("1.1.1.1", "2.2.2.2", "3.3.3.3");
+            assertThat(result.getIpDetails().get("1.1.1.1").isValid()).isTrue();
+        }
+
+        @Test
+        @DisplayName("병렬 처리가 순차보다 빠르다")
+        void shouldBeFasterThanSequential() throws Exception {
+            var file = mockFile();
+            var topIps = List.of(
+                    new AnalysisResult.TopItem("1.1.1.1", 100),
+                    new AnalysisResult.TopItem("2.2.2.2", 50),
+                    new AnalysisResult.TopItem("3.3.3.3", 25));
+
+            when(logParser.parse(any())).thenReturn(createParseResult(3));
+            when(statisticsCalculator.calculate(any())).thenReturn(createStats(topIps));
+            when(ipInfoClient.getIpInfo(anyString())).thenAnswer(inv -> {
+                Thread.sleep(200);
+                String ip = inv.getArgument(0);
+                return IpInfo.of(ip, "KR", "Seoul", "Seoul", "ISP");
+            });
+
+            long start = System.currentTimeMillis();
+            var result = service.analyze(file);
+            long elapsed = System.currentTimeMillis() - start;
+
+            assertThat(result.getIpDetails()).hasSize(3);
+            // 순차: 3 × 200ms = 600ms, 병렬: ~200ms
+            assertThat(elapsed).isLessThan(500);
+        }
+    }
+
+    @Nested
+    @DisplayName("Blank IP 필터링")
+    class BlankIpFilteringTest {
+
+        @Test
+        @DisplayName("blank IP가 TopItem에 포함되어도 크래시 없이 필터링된다")
+        void shouldFilterBlankIps() throws Exception {
+            var file = mockFile();
+            var topIps = List.of(
+                    new AnalysisResult.TopItem("1.1.1.1", 100),
+                    new AnalysisResult.TopItem("", 50));  // blank IP
+
+            when(logParser.parse(any())).thenReturn(createParseResult(2));
+            when(statisticsCalculator.calculate(any())).thenReturn(createStats(topIps));
+            when(ipInfoClient.getIpInfo("1.1.1.1"))
+                    .thenReturn(IpInfo.of("1.1.1.1", "KR", "Seoul", "Seoul", "ISP"));
+
+            var result = service.analyze(file);
+
+            assertThat(result.getIpDetails()).hasSize(1);
+            assertThat(result.getIpDetails()).containsKey("1.1.1.1");
+            // blank IP에 대해 getIpInfo가 호출되지 않아야 함
+            verify(ipInfoClient, never()).getIpInfo("");
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 복원력")
+    class FailureResilienceTest {
+
+        @Test
+        @DisplayName("일부 IP 조회 실패 시 나머지 결과는 정상 반환된다")
+        void shouldReturnPartialResultsOnPartialFailure() throws Exception {
+            var file = mockFile();
+            var topIps = List.of(
+                    new AnalysisResult.TopItem("1.1.1.1", 100),
+                    new AnalysisResult.TopItem("2.2.2.2", 50));
+
+            when(logParser.parse(any())).thenReturn(createParseResult(2));
+            when(statisticsCalculator.calculate(any())).thenReturn(createStats(topIps));
+            when(ipInfoClient.getIpInfo("1.1.1.1"))
+                    .thenReturn(IpInfo.of("1.1.1.1", "KR", "Seoul", "Seoul", "ISP"));
+            when(ipInfoClient.getIpInfo("2.2.2.2"))
+                    .thenThrow(new RuntimeException("API 장애"));
+
+            var result = service.analyze(file);
+
+            assertThat(result.getIpDetails()).hasSize(2);
+            assertThat(result.getIpDetails().get("1.1.1.1").isValid()).isTrue();
+            // 실패한 IP는 unknown으로 fallback
+            assertThat(result.getIpDetails().get("2.2.2.2").isValid()).isFalse();
+        }
+
+        @Test
+        @DisplayName("전체 IP 조회 실패 시에도 분석 결과는 반환된다")
+        void shouldReturnResultEvenWhenAllIpLookupsFail() throws Exception {
+            var file = mockFile();
+            var topIps = List.of(new AnalysisResult.TopItem("1.1.1.1", 100));
+
+            when(logParser.parse(any())).thenReturn(createParseResult(1));
+            when(statisticsCalculator.calculate(any())).thenReturn(createStats(topIps));
+            when(ipInfoClient.getIpInfo(anyString()))
+                    .thenThrow(new RuntimeException("전체 장애"));
+
+            var result = service.analyze(file);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getStatistics().totalRequests()).isEqualTo(100);
+            assertThat(result.getIpDetails().get("1.1.1.1").isValid()).isFalse();
+        }
+
+        @Test
+        @DisplayName("중복 IP는 한 번만 조회된다")
+        void shouldDeduplicateIps() throws Exception {
+            var file = mockFile();
+            var topIps = List.of(
+                    new AnalysisResult.TopItem("1.1.1.1", 100),
+                    new AnalysisResult.TopItem("1.1.1.1", 50));  // 중복
+
+            when(logParser.parse(any())).thenReturn(createParseResult(2));
+            when(statisticsCalculator.calculate(any())).thenReturn(createStats(topIps));
+
+            var callCount = new AtomicInteger(0);
+            when(ipInfoClient.getIpInfo("1.1.1.1")).thenAnswer(inv -> {
+                callCount.incrementAndGet();
+                return IpInfo.of("1.1.1.1", "KR", "Seoul", "Seoul", "ISP");
+            });
+
+            service.analyze(file);
+
+            assertThat(callCount.get()).isEqualTo(1);
+        }
+    }
+}

--- a/src/test/java/com/electricip/loganalyzer/application/AnalysisServiceTest.java
+++ b/src/test/java/com/electricip/loganalyzer/application/AnalysisServiceTest.java
@@ -5,6 +5,7 @@ import com.electricip.loganalyzer.domain.*;
 import com.electricip.loganalyzer.infrastructure.client.IpInfoClient;
 import com.electricip.loganalyzer.infrastructure.parser.CsvLogParser;
 import com.electricip.loganalyzer.infrastructure.repository.AnalysisRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -18,7 +19,10 @@ import java.io.ByteArrayInputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,14 +39,20 @@ class AnalysisServiceTest {
     @Mock private StatisticsCalculator statisticsCalculator;
 
     private AnalysisService service;
+    private ExecutorService executor;
 
     @BeforeEach
     void setUp() {
         var properties = new LogAnalysisProperties(200_000, 10, 50, 5);
-        var executor = Executors.newVirtualThreadPerTaskExecutor();
+        executor = Executors.newVirtualThreadPerTaskExecutor();
         service = new AnalysisService(
                 logParser, ipInfoClient, repository,
                 statisticsCalculator, properties, executor);
+    }
+
+    @AfterEach
+    void tearDown() {
+        executor.close();
     }
 
     private CsvLogParser.ParseResult createParseResult(int logCount) {
@@ -107,29 +117,30 @@ class AnalysisServiceTest {
         }
 
         @Test
-        @DisplayName("병렬 처리가 순차보다 빠르다")
-        void shouldBeFasterThanSequential() throws Exception {
+        @DisplayName("IP 조회가 병렬로 실행된다")
+        void shouldRunConcurrently() throws Exception {
             var file = mockFile();
             var topIps = List.of(
                     new AnalysisResult.TopItem("1.1.1.1", 100),
                     new AnalysisResult.TopItem("2.2.2.2", 50),
                     new AnalysisResult.TopItem("3.3.3.3", 25));
 
+            // 3개 스레드가 모두 도착해야 통과하는 배리어
+            var barrier = new CountDownLatch(3);
+
             when(logParser.parse(any())).thenReturn(createParseResult(3));
             when(statisticsCalculator.calculate(any())).thenReturn(createStats(topIps));
             when(ipInfoClient.getIpInfo(anyString())).thenAnswer(inv -> {
-                Thread.sleep(200);
+                barrier.countDown();
+                // 순차 실행이면 여기서 영원히 대기 (3개가 동시에 도착해야 통과)
+                assertThat(barrier.await(3, TimeUnit.SECONDS)).isTrue();
                 String ip = inv.getArgument(0);
                 return IpInfo.of(ip, "KR", "Seoul", "Seoul", "ISP");
             });
 
-            long start = System.currentTimeMillis();
             var result = service.analyze(file);
-            long elapsed = System.currentTimeMillis() - start;
 
             assertThat(result.getIpDetails()).hasSize(3);
-            // 순차: 3 × 200ms = 600ms, 병렬: ~200ms
-            assertThat(elapsed).isLessThan(500);
         }
     }
 

--- a/src/test/java/com/electricip/loganalyzer/domain/AccessLogTest.java
+++ b/src/test/java/com/electricip/loganalyzer/domain/AccessLogTest.java
@@ -112,8 +112,14 @@ class AccessLogTest {
             assertThat(createLog(null).statusCategory()).isEqualTo("Unknown");
         }
 
+        @ParameterizedTest(name = "상태 코드 {0}은 1xx 카테고리이다")
+        @ValueSource(ints = {100, 199})
+        void shouldReturn1xx_whenStatusIs100to199(int status) {
+            assertThat(createLog(status).statusCategory()).isEqualTo("1xx");
+        }
+
         @ParameterizedTest(name = "상태 코드 {0}은 Unknown 카테고리이다")
-        @ValueSource(ints = {0, 100, 199, 600, 999})
+        @ValueSource(ints = {0, 600, 999})
         void shouldReturnUnknown_whenStatusIsOutOfRange(int status) {
             assertThat(createLog(status).statusCategory()).isEqualTo("Unknown");
         }

--- a/src/test/java/com/electricip/loganalyzer/infrastructure/parser/CsvLogParserTest.java
+++ b/src/test/java/com/electricip/loganalyzer/infrastructure/parser/CsvLogParserTest.java
@@ -32,7 +32,7 @@ class CsvLogParserTest {
 
     @BeforeEach
     void setUp() {
-        parser = new CsvLogParser(new LogAnalysisProperties(200_000, 10, 50));
+        parser = new CsvLogParser(new LogAnalysisProperties(200_000, 10, 50, 5));
     }
 
     private ByteArrayInputStream toStream(String csv) {

--- a/src/test/java/com/electricip/loganalyzer/infrastructure/repository/AnalysisRepositoryTest.java
+++ b/src/test/java/com/electricip/loganalyzer/infrastructure/repository/AnalysisRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.electricip.loganalyzer.infrastructure.repository;
 
 import com.electricip.loganalyzer.domain.AnalysisResult;
+import com.electricip.loganalyzer.domain.exception.DuplicateAnalysisIdException;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,10 +58,13 @@ class AnalysisRepositoryTest {
         }
 
         @Test
-        @DisplayName("같은 ID로 저장하면 덮어쓴다")
-        void shouldOverwriteSameId() {
+        @DisplayName("같은 ID로 저장하면 DuplicateAnalysisIdException 발생")
+        void shouldThrowForDuplicateId() {
             repository.save(createResult("test-1"));
-            repository.save(createResult("test-1"));
+
+            assertThatThrownBy(() -> repository.save(createResult("test-1")))
+                    .isInstanceOf(DuplicateAnalysisIdException.class)
+                    .hasMessageContaining("test-1");
 
             assertThat(repository.count()).isEqualTo(1);
         }


### PR DESCRIPTION
## Summary
IP enrichment 처리를 병렬화하여 분석 성능을 개선하고,
도메인 불변성·상태 코드 분류·빌드 설정을 함께 정리
Virtual Threads 적용을 위해 최소 빌드 JDK를 21로 상향

## Context
### Issue #15 
- Issue: #15 

### Background
- IP enrichment가 순차 처리되어 Top IP 수에 비례해 응답 시간이 증가
- 일부 도메인 타입에서 불필요한 복사 및 누락된 분류가 있었음
- Virtual Threads 사용을 위해 최소 빌드 JDK를 21로 상향할 필요가 있었음(런타임은 JDK 23)
- "같은 ID로 저장하면 덮어쓴다" → "같은 ID로 저장하면 DuplicateAnalysisIdException 발생"으로 변경 완료 ( UUID 중복이 발생했다면 그건 정상 상황이 아니라 버그 신호로 판단)

## Changes

### Performance
- IP enrichment 순차 → 병렬 처리 (Virtual Threads / CompletableFuture)
- 전체 타임아웃 5초 적용
- 실패 시 부분 결과 반환 (fail-safe)
- blank IP 입력 방어 처리

### Domain / Code Quality
- ParseStatistics 불변성 검증 및 중복 copy 제거
- AccessLog에 1xx 상태 코드 분류 추가
- DuplicateAnalysisIdException 관련 dead code 제거

### Build / Infra
- Java 21 toolchain + Foojay resolver 적용
- deprecated timeout API 제거
- AnalysisRepository count API 개선
- @ConfigurationProperties 기반 설정 주입으로 전환

### Test
- AnalysisService 병렬 처리 테스트 7건 추가
- 기존 테스트 전체 통과

## Behavior Change
- Before:
  - Top IP 수 증가 시 응답 시간 선형 증가
  - IP 조회 실패 시 전체 enrichment 실패 가능

- After:
  - IP enrichment 병렬 처리로 최대 10배 성능 개선
  - 실패한 IP만 fallback 처리, 나머지는 정상 반환

## Performance Impact
  - Before: 10 IP × ~200ms ≈ ~2000ms (sequential)
  - After: ≈ max single call latency (~200ms, best case)
  - Theoretical improvement: up to ~10x

## Test
```bash
./gradlew clean test
```

## Risk & Rollback
- Risk: Virtual Threads 사용 고민 결과 Java 17 → 21 변경 
- Rollback: IP enrichment 로직만 순차 구현으로 즉시 복원 가능