### PR TITLE
perf: StatisticsCalculator 단일 루프 기반 성능 최적화

### DIFF
--- a/src/main/java/com/electricip/loganalyzer/application/StatisticsCalculator.java
+++ b/src/main/java/com/electricip/loganalyzer/application/StatisticsCalculator.java
@@ -7,10 +7,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * 통계 계산기
@@ -34,71 +34,56 @@ public class StatisticsCalculator {
         if (logs.isEmpty()) {
             return createEmptyStatistics();
         }
-        
-        // 상태 코드별 카운트
-        var statusCounts = logs.stream()
-                .collect(Collectors.groupingBy(
-                        AccessLog::statusCategory,
-                        Collectors.counting()));
-        
-        // 상위 N개 Path
-        var topPaths = calculateTopN(logs.stream()
-                .filter(log -> log.requestUri() != null)
-                .collect(Collectors.groupingBy(
-                        AccessLog::requestUri,
-                        Collectors.counting())));
-        
-        // 상위 N개 상태 코드
-        var topStatusCodes = calculateTopN(logs.stream()
-                .filter(log -> log.httpStatus() != null)
-                .collect(Collectors.groupingBy(
-                        log -> String.valueOf(log.httpStatus()),
-                        Collectors.counting())));
-        
-        // 상위 N개 IP
-        var topIps = calculateTopN(logs.stream()
-                .filter(log -> log.clientIp() != null)
-                .collect(Collectors.groupingBy(
-                        AccessLog::clientIp,
-                        Collectors.counting())));
-        
-        // HTTP 메서드 통계
-        var methodStats = logs.stream()
-                .filter(log -> log.httpMethod() != null)
-                .collect(Collectors.groupingBy(
-                        AccessLog::httpMethod,
-                        Collectors.counting()));
-        
-        // 평균 응답 시간
-        var avgResponseTime = logs.stream()
-                .filter(log -> log.clientResponseTime() != null)
-                .mapToDouble(AccessLog::clientResponseTime)
-                .average()
-                .orElse(0.0);
-        
-        // 평균 송신 바이트
-        var avgSentBytes = logs.stream()
-                .filter(log -> log.sentBytes() != null)
-                .mapToLong(AccessLog::sentBytes)
-                .average()
-                .orElse(0.0);
-        
-        // 총 트래픽
-        var totalTraffic = logs.stream()
-                .filter(log -> log.sentBytes() != null)
-                .mapToLong(AccessLog::sentBytes)
-                .sum();
-        
+
+        var statusCounts = new HashMap<String, Long>();
+        var pathCounts = new HashMap<String, Long>();
+        var statusCodeCounts = new HashMap<String, Long>();
+        var ipCounts = new HashMap<String, Long>();
+        var methodCounts = new HashMap<String, Long>();
+
+        var responseTimeSum = 0.0;
+        var responseTimeCount = 0;
+        var totalTraffic = 0L;
+        var sentBytesCount = 0;
+
+        for (var log : logs) {
+            statusCounts.merge(log.statusCategory(), 1L, Long::sum);
+
+            if (log.requestUri() != null) {
+                pathCounts.merge(log.requestUri(), 1L, Long::sum);
+            }
+            if (log.httpStatus() != null) {
+                statusCodeCounts.merge(String.valueOf(log.httpStatus()), 1L, Long::sum);
+            }
+            if (log.clientIp() != null) {
+                ipCounts.merge(log.clientIp(), 1L, Long::sum);
+            }
+            if (log.httpMethod() != null) {
+                methodCounts.merge(log.httpMethod(), 1L, Long::sum);
+            }
+            if (log.clientResponseTime() != null) {
+                responseTimeSum += log.clientResponseTime();
+                responseTimeCount++;
+            }
+            if (log.sentBytes() != null) {
+                totalTraffic += log.sentBytes();
+                sentBytesCount++;
+            }
+        }
+
+        var avgResponseTime = (responseTimeCount > 0) ? responseTimeSum / responseTimeCount : 0.0;
+        var avgSentBytes = (sentBytesCount > 0) ? (double) totalTraffic / sentBytesCount : 0.0;
+
         return AnalysisResult.Statistics.builder()
                 .totalRequests(logs.size())
                 .successCount(statusCounts.getOrDefault("2xx", 0L))
                 .redirectCount(statusCounts.getOrDefault("3xx", 0L))
                 .clientErrorCount(statusCounts.getOrDefault("4xx", 0L))
                 .serverErrorCount(statusCounts.getOrDefault("5xx", 0L))
-                .topPaths(topPaths)
-                .topStatusCodes(topStatusCodes)
-                .topIps(topIps)
-                .methodStats(methodStats)
+                .topPaths(calculateTopN(pathCounts))
+                .topStatusCodes(calculateTopN(statusCodeCounts))
+                .topIps(calculateTopN(ipCounts))
+                .methodStats(methodCounts)
                 .avgResponseTime(avgResponseTime)
                 .avgSentBytes(avgSentBytes)
                 .totalTraffic(totalTraffic)


### PR DESCRIPTION
## Summary
<!-- 이 PR이 무엇을 변경하는지 한 줄 요약 -->
대량 로그 처리 시 병목이 되었던 StatisticsCalculator의 다중 stream 기반 집계를
단일 루프 + HashMap.merge() 구조로 변경하여 순회 횟수·메모리 할당·GC 부담을 크게 감소

## Context
<!-- 왜 이 변경이 필요한지 / 배경 -->
- Issue: #16 
###  Background
- 기존 구현은 통계 항목별로 stream을 반복 사용하며 동일 컬렉션을 최대 8회 순회
- 각 stream마다 중간 Map이 생성되어 CPU 캐시 효율과 GC 부담 증가
- 200k 로그 기준 불필요한 연산량이 과도하게 발생

## Changes
<!-- 변경 사항을 계층별로 간결하게 -->
### Performance
- 다중 stream 집계 → 단일 for 루프로 통합
- 중간 컬렉션 생성 제거, HashMap.merge() 직접 사용
- null 필터링을 루프 내부 1회로 축소

### Code Quality
- Collectors import 제거
- 제어 흐름이 명시적인 imperative 로직으로 변경되어 디버깅 용이성 개선

### Impact

200k 로그 기준
- 접근 횟수: 160만 → 20만
- CPU 캐시 효율 개선
- GC pressure 감소

결과값 및 외부 동작은 기존과 동일 (behavior change 없음)

---

## Code Convention Checklist
> 본 PR은 프로젝트 코드 컨벤션을 기준으로 검토합니다.  
> 세부 기준은 `docs/CODE_CONVENTION.md`를 따릅니다.

### 1. 객체 생성 & 수명 관리
- [ ] 생성 로직은 생성자 대신 **정적 팩터리 메서드** 또는 **빌더**로 캡슐화했다
- [ ] 매개변수가 많은 객체는 **Builder 패턴**을 사용했다
- [ ] 의존 객체는 **생성자 주입**으로 전달했다
- [ ] 자원 사용 시 **try-with-resources**를 적용했다

### 2. 불변성 & 스레드 안정성
- [ ] 도메인 객체는 **불변(record / @Value)** 으로 설계했다
- [ ] 내부 상태는 외부에서 수정할 수 없도록 보호했다
- [ ] 동시 접근 가능 구조에는 **thread-safe 컬렉션**을 사용했다

### 3. 메서드 계약
- [ ] public 메서드는 **매개변수 유효성 검사**를 수행한다
- [ ] `null` 대신 **Optional 또는 빈 컬렉션**을 반환한다
- [ ] 컬렉션/배열은 **방어적 복사** 또는 불변 래핑을 적용했다
- [ ] 실패 케이스는 **Fail-Fast**로 드러난다

### 4. 계층 분리
- [ ] Domain 레이어는 **외부 의존성(프레임워크/IO)** 이 없다
- [ ] 외부 시스템 연동은 Infrastructure 레이어에 격리했다
- [ ] Application 레이어는 오케스트레이션 책임만 가진다

### 5. 예외 & 로깅
- [ ] 예외 메시지는 **행동 가능한 정보**를 포함한다
- [ ] 성공/실패 로그 레벨을 구분했다
- [ ] 민감 정보는 로그에 남기지 않았다

---

## Behavior Change
<!-- 사용자/클라이언트 관점에서의 동작 변화 -->
| 항목 | Before | After |
-- | -- | --
| 순회 횟수 | 8회 (stream 8개) | 1회 (단일 루프) |
| 중간 컬렉션 | stream마다 Map 생성 | 없음 |
| null 체크 | stream마다 filter | 루프 내 1회 |
| import | Collectors 필요 | 제거 |

## Test
```bash
./gradlew test
./gradlew build
```
- 기존 테스트 전체 통과
- 통계 결과 정합성 유지 확인

## Risk & Rollback
###  Risk: 
- 통계 계산 로직을 stream 기반에서 단일 루프 기반으로 변경함
→ 로직 단순화로 가독성과 성능은 개선되었으나, 집계 기준 변경 가능성이 이론적으로 존재
- 다만 기존 테스트 + 대량 로그 기준 검증을 통해 결과 동일성 확인 완료
- 외부 API / 데이터 모델 / 비즈니스 규칙 변경 없음

### Rollback:
- 롤백 시 기존 stream 기반 구현으로 즉시 복구 가능
- DB 스키마, 외부 인터페이스, 설정 변경이 없어 재배포만으로 원복 가능
- 데이터 마이그레이션 불필요