### PR TITLE
refactor: DIP 적용을 위한 인터페이스 추출 및 IpInfoClient 오류 처리 개선

### DIFF
--- a/src/main/java/com/electricip/loganalyzer/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/electricip/loganalyzer/api/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package com.electricip.loganalyzer.api;
 
-import com.electricip.loganalyzer.domain.InvalidCsvFormatException;
+import com.electricip.loganalyzer.domain.exception.InvalidCsvFormatException;
 import com.electricip.loganalyzer.domain.exception.AnalysisNotFoundException;
 import com.electricip.loganalyzer.domain.exception.DuplicateAnalysisIdException;
 import com.electricip.loganalyzer.domain.exception.FileTooLargeException;

--- a/src/main/java/com/electricip/loganalyzer/application/AnalysisResultRepository.java
+++ b/src/main/java/com/electricip/loganalyzer/application/AnalysisResultRepository.java
@@ -1,0 +1,22 @@
+package com.electricip.loganalyzer.application;
+
+import com.electricip.loganalyzer.domain.AnalysisResult;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 분석 결과 저장소 인터페이스
+ */
+public interface AnalysisResultRepository {
+
+    void save(AnalysisResult result);
+
+    Optional<AnalysisResult> findById(String analysisId);
+
+    List<AnalysisResult> findAll();
+
+    boolean deleteById(String analysisId);
+
+    long count();
+}

--- a/src/main/java/com/electricip/loganalyzer/application/AnalysisService.java
+++ b/src/main/java/com/electricip/loganalyzer/application/AnalysisService.java
@@ -9,8 +9,6 @@ import com.electricip.loganalyzer.domain.exception.LogAnalyzerException;
 import com.electricip.loganalyzer.domain.exception.LogParsingException;
 import com.electricip.loganalyzer.domain.exception.TooManyParsingErrorsException;
 import com.electricip.loganalyzer.infrastructure.client.IpInfoClient;
-import com.electricip.loganalyzer.infrastructure.parser.CsvLogParser;
-import com.electricip.loganalyzer.infrastructure.repository.AnalysisRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -32,9 +30,9 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class AnalysisService {
 
-    private final CsvLogParser logParser;
+    private final LogParser logParser;
     private final IpInfoClient ipInfoClient;
-    private final AnalysisRepository repository;
+    private final AnalysisResultRepository repository;
     private final StatisticsCalculator statisticsCalculator;
     private final LogAnalysisProperties properties;
     private final Executor ipEnrichmentExecutor;

--- a/src/main/java/com/electricip/loganalyzer/application/LogParser.java
+++ b/src/main/java/com/electricip/loganalyzer/application/LogParser.java
@@ -1,0 +1,26 @@
+package com.electricip.loganalyzer.application;
+
+import com.electricip.loganalyzer.domain.AccessLog;
+import com.electricip.loganalyzer.domain.ParseStatistics;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * 로그 파서 인터페이스
+ */
+public interface LogParser {
+
+    ParseResult parse(InputStream inputStream);
+
+    record ParseResult(
+            List<AccessLog> logs,
+            ParseStatistics parseStatistics
+    ) {
+        public ParseResult {
+            logs = List.copyOf(logs);
+            Objects.requireNonNull(parseStatistics, "parseStatistics는 null일 수 없습니다");
+        }
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/domain/exception/InvalidCsvFormatException.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/exception/InvalidCsvFormatException.java
@@ -1,6 +1,5 @@
-package com.electricip.loganalyzer.domain;
+package com.electricip.loganalyzer.domain.exception;
 
-import com.electricip.loganalyzer.domain.exception.LogAnalyzerException;
 import lombok.Getter;
 
 import java.util.List;

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoClient.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/client/IpInfoClient.java
@@ -69,7 +69,7 @@ public class IpInfoClient {
                 if (attempt >= MAX_ATTEMPTS) {
                     circuitBreaker.recordFailure();
                     log.warn("ipinfo API 유효하지 않은 응답: ip={}, attempts={}", ip, MAX_ATTEMPTS);
-                    return result;
+                    return IpInfo.unknown(ip);
                 }
                 log.warn("ipinfo API 유효하지 않은 응답, 재시도: ip={}, attempt={}/{}",
                         ip, attempt, MAX_ATTEMPTS);
@@ -77,7 +77,7 @@ public class IpInfoClient {
                 if (sleep(BACKOFF_MS * attempt)) {
                     log.warn("ipinfo API 재시도 중단 (인터럽트): ip={}", ip);
                     circuitBreaker.recordFailure();
-                    return result;
+                    return IpInfo.unknown(ip);
                 }
 
             } catch (RateLimitExceededException e) {

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/parser/CsvLogParser.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/parser/CsvLogParser.java
@@ -1,7 +1,8 @@
 package com.electricip.loganalyzer.infrastructure.parser;
 
+import com.electricip.loganalyzer.application.LogParser;
 import com.electricip.loganalyzer.domain.AccessLog;
-import com.electricip.loganalyzer.domain.InvalidCsvFormatException;
+import com.electricip.loganalyzer.domain.exception.InvalidCsvFormatException;
 import com.electricip.loganalyzer.domain.ParseError;
 import com.electricip.loganalyzer.domain.ParseStatistics;
 import com.electricip.loganalyzer.config.LogAnalysisProperties;
@@ -20,6 +21,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * CSV 로그 파서
@@ -27,7 +29,7 @@ import java.util.*;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class CsvLogParser {
+public class CsvLogParser implements LogParser {
 
     private static final DateTimeFormatter FORMATTER =
             DateTimeFormatter.ofPattern("M/d/yyyy, h:mm:ss.SSS a", Locale.ENGLISH);
@@ -133,7 +135,7 @@ public class CsvLogParser {
     private void validateHeaders(Map<String, Integer> headerMap) {
         var actualHeaders = headerMap.keySet().stream()
                 .map(h -> h.toLowerCase(Locale.ROOT))
-                .collect(java.util.stream.Collectors.toSet());
+                .collect(Collectors.toSet());
 
         var missingHeaders = REQUIRED_HEADERS.stream()
                 .filter(required -> !actualHeaders.contains(required.toLowerCase(Locale.ROOT)))
@@ -215,16 +217,4 @@ public class CsvLogParser {
         }
     }
 
-    /**
-     * 파싱 결과 (Record)
-     */
-    public record ParseResult(
-            List<AccessLog> logs,
-            ParseStatistics parseStatistics
-    ) {
-        public ParseResult {
-            logs = List.copyOf(logs);
-            Objects.requireNonNull(parseStatistics, "parseStatistics는 null일 수 없습니다");
-        }
-    }
 }

--- a/src/main/java/com/electricip/loganalyzer/infrastructure/repository/AnalysisRepository.java
+++ b/src/main/java/com/electricip/loganalyzer/infrastructure/repository/AnalysisRepository.java
@@ -1,5 +1,6 @@
 package com.electricip.loganalyzer.infrastructure.repository;
 
+import com.electricip.loganalyzer.application.AnalysisResultRepository;
 import com.electricip.loganalyzer.domain.AnalysisResult;
 import com.electricip.loganalyzer.domain.exception.DuplicateAnalysisIdException;
 import com.github.benmanes.caffeine.cache.Cache;
@@ -19,7 +20,7 @@ import java.util.concurrent.TimeUnit;
  */
 @Slf4j
 @Repository
-public class AnalysisRepository {
+public class AnalysisRepository implements AnalysisResultRepository {
 
     private final Cache<String, AnalysisResult> storage;
 

--- a/src/test/java/com/electricip/loganalyzer/api/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/electricip/loganalyzer/api/GlobalExceptionHandlerTest.java
@@ -1,6 +1,6 @@
 package com.electricip.loganalyzer.api;
 
-import com.electricip.loganalyzer.domain.InvalidCsvFormatException;
+import com.electricip.loganalyzer.domain.exception.InvalidCsvFormatException;
 import com.electricip.loganalyzer.domain.ParseError;
 import com.electricip.loganalyzer.domain.exception.AnalysisNotFoundException;
 import com.electricip.loganalyzer.domain.exception.DuplicateAnalysisIdException;

--- a/src/test/java/com/electricip/loganalyzer/application/AnalysisServiceTest.java
+++ b/src/test/java/com/electricip/loganalyzer/application/AnalysisServiceTest.java
@@ -3,8 +3,6 @@ package com.electricip.loganalyzer.application;
 import com.electricip.loganalyzer.config.LogAnalysisProperties;
 import com.electricip.loganalyzer.domain.*;
 import com.electricip.loganalyzer.infrastructure.client.IpInfoClient;
-import com.electricip.loganalyzer.infrastructure.parser.CsvLogParser;
-import com.electricip.loganalyzer.infrastructure.repository.AnalysisRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -36,9 +34,9 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class AnalysisServiceTest {
 
-    @Mock private CsvLogParser logParser;
+    @Mock private LogParser logParser;
     @Mock private IpInfoClient ipInfoClient;
-    @Mock private AnalysisRepository repository;
+    @Mock private AnalysisResultRepository repository;
     @Mock private StatisticsCalculator statisticsCalculator;
 
     private AnalysisService service;
@@ -58,11 +56,11 @@ class AnalysisServiceTest {
         executor.close();
     }
 
-    private CsvLogParser.ParseResult createParseResult(int logCount) {
+    private LogParser.ParseResult createParseResult(int logCount) {
         var logs = Collections.nCopies(logCount, new AccessLog(
                 null, "1.1.1.1", "GET", "/api/test", "Mozilla",
                 200, "HTTP/1.1", 100L, 200L, 0.5, "TLSv1.2", "/api/test"));
-        return new CsvLogParser.ParseResult(logs,
+        return new LogParser.ParseResult(logs,
                 new ParseStatistics(logCount, logCount, 0, Map.of(), List.of()));
     }
 

--- a/src/test/java/com/electricip/loganalyzer/domain/exception/InvalidCsvFormatExceptionTest.java
+++ b/src/test/java/com/electricip/loganalyzer/domain/exception/InvalidCsvFormatExceptionTest.java
@@ -1,6 +1,5 @@
-package com.electricip.loganalyzer.domain;
+package com.electricip.loganalyzer.domain.exception;
 
-import com.electricip.loganalyzer.domain.exception.LogAnalyzerException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/electricip/loganalyzer/infrastructure/parser/CsvLogParserTest.java
+++ b/src/test/java/com/electricip/loganalyzer/infrastructure/parser/CsvLogParserTest.java
@@ -1,7 +1,8 @@
 package com.electricip.loganalyzer.infrastructure.parser;
 
+import com.electricip.loganalyzer.application.LogParser;
 import com.electricip.loganalyzer.config.LogAnalysisProperties;
-import com.electricip.loganalyzer.domain.InvalidCsvFormatException;
+import com.electricip.loganalyzer.domain.exception.InvalidCsvFormatException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -154,7 +155,7 @@ class CsvLogParserTest {
             int threadCount = 10;
             var executor = Executors.newFixedThreadPool(threadCount);
             var latch = new CountDownLatch(threadCount);
-            var tasks = new ArrayList<Future<CsvLogParser.ParseResult>>();
+            var tasks = new ArrayList<Future<LogParser.ParseResult>>();
 
             for (int i = 0; i < threadCount; i++) {
                 tasks.add(executor.submit(() -> {
@@ -184,7 +185,7 @@ class CsvLogParserTest {
             int threadCount = 10;
             var executor = Executors.newFixedThreadPool(threadCount);
             var latch = new CountDownLatch(threadCount);
-            var tasks = new ArrayList<Future<CsvLogParser.ParseResult>>();
+            var tasks = new ArrayList<Future<LogParser.ParseResult>>();
 
             for (int i = 0; i < threadCount; i++) {
                 final int rowCount = i + 1; // 각 스레드가 다른 행 수


### PR DESCRIPTION
## Summary
<!-- 이 PR이 무엇을 변경하는지 한 줄 요약 -->
AnalysisService의 의존성을 인터페이스로 분리하여 DIP를 적용하고,
IpInfoClient에서 유효하지 않은 응답 처리 버그를 수정

## Context
<!-- 왜 이 변경이 필요한지 / 배경 -->
AnalysisService가 구체 구현체(CsvLogParser, AnalysisRepository)에 직접 의존하고 있어
테스트와 확장에 제약이 있었음
도메인 예외가 패키지 루트에 흩어져 있어 책임 경계가 불명확했음
IpInfoClient에서 재시도 실패 시 잘못된 결과 객체를 그대로 반환하는 버그 존재

## Changes
<!-- 변경 사항을 계층별로 간결하게 -->
### Architecture / Refactoring
- LogParser 인터페이스 추출 및 CsvLogParser 구현체로 분리
- AnalysisResultRepository 인터페이스 추출 및 AnalysisRepository 구현체로 분리
- AnalysisService가 구체 클래스 대신 인터페이스에 의존하도록 변경
- ParseResult record를 LogParser 인터페이스로 이동

### Domain
- InvalidCsvFormatException을 domain.exception 패키지로 이동
- 관련 import 및 테스트 경로 정리

### Bug Fix
- IpInfoClient에서 유효하지 않은 응답 발생 시
- 기존 result 대신 IpInfo.unknown(ip) 반환하도록 수정

---

## Code Convention Checklist
> 본 PR은 프로젝트 코드 컨벤션을 기준으로 검토합니다.  
> 세부 기준은 `docs/CODE_CONVENTION.md`를 따릅니다.

### 1. 객체 생성 & 수명 관리
- [x] 생성 로직은 생성자 대신 **정적 팩터리 메서드** 또는 **빌더**로 캡슐화했다
- [x] 매개변수가 많은 객체는 **Builder 패턴**을 사용했다
- [x] 의존 객체는 **생성자 주입**으로 전달했다
- [ ] 자원 사용 시 **try-with-resources**를 적용했다

### 2. 불변성 & 스레드 안정성
- [x] 도메인 객체는 **불변(record / @Value)** 으로 설계했다
- [x] 내부 상태는 외부에서 수정할 수 없도록 보호했다
- [x] 동시 접근 가능 구조에는 **thread-safe 컬렉션**을 사용했다

### 3. 메서드 계약
- [x] public 메서드는 **매개변수 유효성 검사**를 수행한다
- [x] `null` 대신 **Optional 또는 빈 컬렉션**을 반환한다
- [x] 컬렉션/배열은 **방어적 복사** 또는 불변 래핑을 적용했다
- [x] 실패 케이스는 **Fail-Fast**로 드러난다

### 4. 계층 분리
- [ ] Domain 레이어는 **외부 의존성(프레임워크/IO)** 이 없다
- [ ] 외부 시스템 연동은 Infrastructure 레이어에 격리했다
- [ ] Application 레이어는 오케스트레이션 책임만 가진다

### 5. 예외 & 로깅
- [ ] 예외 메시지는 **행동 가능한 정보**를 포함한다
- [ ] 성공/실패 로그 레벨을 구분했다
- [ ] 민감 정보는 로그에 남기지 않았다

---

## Behavior Change
<!-- 사용자/클라이언트 관점에서의 동작 변화 -->
- Before:  IP 정보 조회 실패 시, 일부 경우 유효하지 않은 IpInfo 객체가 그대로 반환될 수 있었음
- After: IP 정보 조회가 실패하거나 응답이 유효하지 않은 경우 항상 IpInfo.unknown(ip)을 반환하여
API 응답 구조와 의미가 일관되게 유지됨

## Test
```bash
./gradlew test
./gradlew build
```

## Risk & Rollback
- Risk: 인터페이스 도입으로 인한 컴파일 경로 변경
기존 기능 동작 방식은 변경되지 않음
- Rollback: 해당 PR revert 시 기존 구현체 의존 구조로 복구 가능