### PR TITLE
feat: 통계 계산 실패 처리 및 분석 경고(warnings) 지원

### DIFF
--- a/src/main/java/com/electricip/loganalyzer/api/AnalysisResponse.java
+++ b/src/main/java/com/electricip/loganalyzer/api/AnalysisResponse.java
@@ -28,11 +28,14 @@ public record AnalysisResponse(
         @NonNull TopStats topStats,
         @NonNull List<IpDetail> ipDetails,
         @NonNull ParseStatisticsDto parseStatistics,
-        @NonNull AdditionalStats additionalStats
+        @NonNull AdditionalStats additionalStats,
+        @Schema(description = "경고 메시지 목록")
+        @NonNull List<String> warnings
 ) {
 
     public AnalysisResponse {
         ipDetails = List.copyOf(ipDetails);
+        warnings = List.copyOf(warnings);
     }
 
     /**
@@ -68,6 +71,7 @@ public record AnalysisResponse(
                         stats.avgResponseTime(),
                         stats.avgSentBytes(),
                         stats.totalTraffic()))
+                .warnings(result.getWarnings())
                 .build();
     }
 

--- a/src/main/java/com/electricip/loganalyzer/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/electricip/loganalyzer/api/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import com.electricip.loganalyzer.domain.exception.FileTooLargeException;
 import com.electricip.loganalyzer.domain.exception.InvalidFileException;
 import com.electricip.loganalyzer.domain.exception.LogAnalyzerException;
 import com.electricip.loganalyzer.domain.exception.LogParsingException;
+import com.electricip.loganalyzer.domain.exception.StatisticsCalculationException;
 import com.electricip.loganalyzer.domain.exception.TooManyParsingErrorsException;
 import com.electricip.loganalyzer.infrastructure.client.IpInfoException;
 import com.electricip.loganalyzer.infrastructure.client.RateLimitExceededException;
@@ -98,6 +99,25 @@ public class GlobalExceptionHandler {
                 .badRequest()
                 .body(ErrorResponse.of(
                         HttpStatus.BAD_REQUEST,
+                        e.getErrorCode(),
+                        e.getMessage(),
+                        request.getRequestURI()
+                ));
+    }
+
+    /**
+     * StatisticsCalculationException 처리 → 500
+     */
+    @ExceptionHandler(StatisticsCalculationException.class)
+    public ResponseEntity<ErrorResponse> handleStatisticsCalculation(
+            StatisticsCalculationException e, HttpServletRequest request) {
+
+        log.error("통계 계산 오류: {}", e.getMessage(), e);
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ErrorResponse.of(
+                        HttpStatus.INTERNAL_SERVER_ERROR,
                         e.getErrorCode(),
                         e.getMessage(),
                         request.getRequestURI()

--- a/src/main/java/com/electricip/loganalyzer/application/AnalysisService.java
+++ b/src/main/java/com/electricip/loganalyzer/application/AnalysisService.java
@@ -78,18 +78,28 @@ public class AnalysisService {
                 throw new StatisticsCalculationException("통계 계산에 실패했습니다", e);
             }
 
-            // 3. IP enrichment (실패해도 결과 반환)
+            // 3. topIps 조회 (통계 접근 실패 시 StatisticsCalculationException)
+            List<AnalysisResult.TopItem> topIps;
+            try {
+                topIps = statistics.topIps();
+            } catch (Exception e) {
+                throw new StatisticsCalculationException("통계 데이터 접근에 실패했습니다", e);
+            }
+
+            // 4. IP enrichment (실패해도 결과 반환)
             var warnings = new ArrayList<String>();
             Map<String, IpInfo> ipDetails;
             try {
-                ipDetails = enrichIpInfo(statistics.topIps());
+                var enrichmentResult = enrichIpInfo(topIps);
+                ipDetails = enrichmentResult.ipDetails();
+                warnings.addAll(enrichmentResult.warnings());
             } catch (Exception e) {
                 log.warn("IP enrichment 전체 실패, 빈 결과로 대체: {}", e.getMessage(), e);
                 ipDetails = Collections.emptyMap();
                 warnings.add("IP 정보 조회에 실패했습니다: " + e.getMessage());
             }
 
-            // 4. 결과 생성
+            // 5. 결과 생성
             var result = AnalysisResult.builder()
                     .analysisId(UUID.randomUUID().toString())
                     .completedAt(LocalDateTime.now())
@@ -100,7 +110,7 @@ public class AnalysisService {
                     .parseStatistics(parseResult.parseStatistics())
                     .build();
 
-            // 5. 저장
+            // 6. 저장
             repository.save(result);
 
             log.info("분석 완료: id={}, duration={}ms, total={}",
@@ -222,12 +232,14 @@ public class AnalysisService {
         }
     }
     
+    record IpEnrichmentResult(Map<String, IpInfo> ipDetails, List<String> warnings) {}
+
     /**
      * IP 정보 병렬 enrichment (CompletableFuture + 전용 스레드 풀)
      */
-    private Map<String, IpInfo> enrichIpInfo(List<AnalysisResult.TopItem> topIps) {
+    IpEnrichmentResult enrichIpInfo(List<AnalysisResult.TopItem> topIps) {
         if (topIps.isEmpty()) {
-            return Collections.emptyMap();
+            return new IpEnrichmentResult(Collections.emptyMap(), List.of());
         }
 
         var ips = topIps.stream()
@@ -237,7 +249,7 @@ public class AnalysisService {
                 .toList();
 
         if (ips.isEmpty()) {
-            return Collections.emptyMap();
+            return new IpEnrichmentResult(Collections.emptyMap(), List.of());
         }
 
         var timeout = properties.ipEnrichmentTimeoutSeconds();
@@ -257,12 +269,24 @@ public class AnalysisService {
             log.warn("IP enrichment 중 예외 발생, 완료된 결과만 반환", e);
         }
 
-        return futures.entrySet().stream()
+        var ipDetails = futures.entrySet().stream()
                 .filter(entry -> entry.getValue().isDone() && !entry.getValue().isCompletedExceptionally())
                 .collect(Collectors.toMap(
                         Map.Entry::getKey,
                         entry -> entry.getValue().join()
                 ));
+
+        var failedIps = ipDetails.entrySet().stream()
+                .filter(e -> !e.getValue().isValid())
+                .map(Map.Entry::getKey)
+                .toList();
+
+        var warnings = new ArrayList<String>();
+        if (!failedIps.isEmpty()) {
+            warnings.add("일부 IP 정보 조회에 실패했습니다: " + String.join(", ", failedIps));
+        }
+
+        return new IpEnrichmentResult(ipDetails, warnings);
     }
 
     private IpInfo fetchIpInfoSafely(String ip) {

--- a/src/main/java/com/electricip/loganalyzer/application/AnalysisService.java
+++ b/src/main/java/com/electricip/loganalyzer/application/AnalysisService.java
@@ -7,6 +7,7 @@ import com.electricip.loganalyzer.domain.exception.FileTooLargeException;
 import com.electricip.loganalyzer.domain.exception.InvalidFileException;
 import com.electricip.loganalyzer.domain.exception.LogAnalyzerException;
 import com.electricip.loganalyzer.domain.exception.LogParsingException;
+import com.electricip.loganalyzer.domain.exception.StatisticsCalculationException;
 import com.electricip.loganalyzer.domain.exception.TooManyParsingErrorsException;
 import com.electricip.loganalyzer.infrastructure.client.IpInfoClient;
 import lombok.RequiredArgsConstructor;
@@ -70,10 +71,23 @@ public class AnalysisService {
             }
 
             // 2. 통계 계산
-            var statistics = statisticsCalculator.calculate(logs);
+            AnalysisResult.Statistics statistics;
+            try {
+                statistics = statisticsCalculator.calculate(logs);
+            } catch (Exception e) {
+                throw new StatisticsCalculationException("통계 계산에 실패했습니다", e);
+            }
 
-            // 3. IP enrichment
-            var ipDetails = enrichIpInfo(statistics.topIps());
+            // 3. IP enrichment (실패해도 결과 반환)
+            var warnings = new ArrayList<String>();
+            Map<String, IpInfo> ipDetails;
+            try {
+                ipDetails = enrichIpInfo(statistics.topIps());
+            } catch (Exception e) {
+                log.warn("IP enrichment 전체 실패, 빈 결과로 대체: {}", e.getMessage(), e);
+                ipDetails = Collections.emptyMap();
+                warnings.add("IP 정보 조회에 실패했습니다: " + e.getMessage());
+            }
 
             // 4. 결과 생성
             var result = AnalysisResult.builder()
@@ -82,6 +96,7 @@ public class AnalysisService {
                     .processingTimeMs(System.currentTimeMillis() - startTime)
                     .statistics(statistics)
                     .ipDetails(ipDetails)
+                    .warnings(warnings)
                     .parseStatistics(parseResult.parseStatistics())
                     .build();
 

--- a/src/main/java/com/electricip/loganalyzer/domain/AnalysisResult.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/AnalysisResult.java
@@ -3,6 +3,7 @@ package com.electricip.loganalyzer.domain;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -20,6 +21,8 @@ public class AnalysisResult {
     @Singular("ipDetail")
     Map<String, IpInfo> ipDetails;
 
+    List<String> warnings;
+
     ParseStatistics parseStatistics;
 
     /**
@@ -31,6 +34,7 @@ public class AnalysisResult {
             Long processingTimeMs,
             @NonNull Statistics statistics,
             Map<String, IpInfo> ipDetails,
+            List<String> warnings,
             ParseStatistics parseStatistics
     ) {
         this.analysisId = analysisId;
@@ -39,6 +43,7 @@ public class AnalysisResult {
         this.statistics = statistics;
 
         this.ipDetails = (ipDetails == null) ? Map.of() : Map.copyOf(ipDetails);
+        this.warnings = (warnings == null) ? Collections.emptyList() : List.copyOf(warnings);
 
         // 기본값 보장
         this.parseStatistics = (parseStatistics == null) ? ParseStatistics.empty() : parseStatistics;

--- a/src/main/java/com/electricip/loganalyzer/domain/exception/StatisticsCalculationException.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/exception/StatisticsCalculationException.java
@@ -1,0 +1,15 @@
+package com.electricip.loganalyzer.domain.exception;
+
+/**
+ * 통계 계산 중 발생하는 예외
+ */
+public class StatisticsCalculationException extends LogAnalyzerException {
+
+    public StatisticsCalculationException(String message) {
+        super("STATISTICS_CALCULATION_ERROR", message);
+    }
+
+    public StatisticsCalculationException(String message, Throwable cause) {
+        super("STATISTICS_CALCULATION_ERROR", message, cause);
+    }
+}

--- a/src/test/java/com/electricip/loganalyzer/api/AnalysisResponseTest.java
+++ b/src/test/java/com/electricip/loganalyzer/api/AnalysisResponseTest.java
@@ -39,6 +39,7 @@ class AnalysisResponseTest {
                 .ipDetails(Collections.emptyList())
                 .parseStatistics(validParseStatistics())
                 .additionalStats(validAdditionalStats())
+                .warnings(Collections.emptyList())
                 .build();
 
         assertEquals("test-id", response.analysisId());
@@ -99,6 +100,7 @@ class AnalysisResponseTest {
                 .ipDetails(Collections.emptyList())
                 .parseStatistics(validParseStatistics())
                 .additionalStats(validAdditionalStats())
+                .warnings(Collections.emptyList())
                 .build();
 
         assertNull(response.processingTimeMs());

--- a/src/test/java/com/electricip/loganalyzer/application/AnalysisServiceTest.java
+++ b/src/test/java/com/electricip/loganalyzer/application/AnalysisServiceTest.java
@@ -2,6 +2,8 @@ package com.electricip.loganalyzer.application;
 
 import com.electricip.loganalyzer.config.LogAnalysisProperties;
 import com.electricip.loganalyzer.domain.*;
+import com.electricip.loganalyzer.domain.exception.InvalidFileException;
+import com.electricip.loganalyzer.domain.exception.StatisticsCalculationException;
 import com.electricip.loganalyzer.infrastructure.client.IpInfoClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,8 +14,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.multipart.MultipartFile;
-
-import com.electricip.loganalyzer.domain.exception.InvalidFileException;
 
 import java.io.ByteArrayInputStream;
 import java.util.Collections;
@@ -364,6 +364,74 @@ class AnalysisServiceTest {
             service.analyze(file);
 
             assertThat(callCount.get()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("Graceful Degradation")
+    class GracefulDegradationTest {
+
+        @Test
+        @DisplayName("IP enrichment 외부 단계 실패 시 warning 포함 + 빈 ipDetails로 결과 반환")
+        void shouldReturnResultWithWarningWhenIpEnrichmentFails() throws Exception {
+            var file = mockFile();
+            // null item을 포함하면 topIps.stream().map(TopItem::item)에서 NPE 발생 → enrichIpInfo 전체 실패
+            // 대신 statisticsCalculator가 topIps에서 NPE를 유발하는 statistics를 반환하도록 구성
+            var normalStats = createStats(List.of(new AnalysisResult.TopItem("1.1.1.1", 100)));
+
+            when(logParser.parse(any())).thenReturn(createParseResult(1));
+            // statistics.topIps()가 null을 반환하는 mock Statistics를 사용하여 enrichIpInfo에서 NPE 유발
+            var brokenStats = mock(AnalysisResult.Statistics.class);
+            lenient().when(brokenStats.totalRequests()).thenReturn(100L);
+            when(brokenStats.topIps()).thenThrow(new RuntimeException("IP 목록 조회 실패"));
+            lenient().when(brokenStats.successCount()).thenReturn(90L);
+            lenient().when(brokenStats.redirectCount()).thenReturn(5L);
+            lenient().when(brokenStats.clientErrorCount()).thenReturn(3L);
+            lenient().when(brokenStats.serverErrorCount()).thenReturn(2L);
+            lenient().when(brokenStats.topPaths()).thenReturn(List.of());
+            lenient().when(brokenStats.topStatusCodes()).thenReturn(List.of());
+            lenient().when(brokenStats.methodStats()).thenReturn(Map.of());
+            lenient().when(brokenStats.avgResponseTime()).thenReturn(0.5);
+            lenient().when(brokenStats.avgSentBytes()).thenReturn(200.0);
+            lenient().when(brokenStats.totalTraffic()).thenReturn(20000L);
+
+            when(statisticsCalculator.calculate(any())).thenReturn(brokenStats);
+
+            var result = service.analyze(file);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getStatistics().totalRequests()).isEqualTo(100);
+            assertThat(result.getIpDetails()).isEmpty();
+            assertThat(result.getWarnings()).isNotEmpty();
+            assertThat(result.getWarnings().get(0)).contains("IP 정보 조회에 실패했습니다");
+        }
+
+        @Test
+        @DisplayName("통계 계산 실패 시 StatisticsCalculationException 발생")
+        void shouldThrowStatisticsCalculationExceptionWhenCalculationFails() throws Exception {
+            var file = mockFile();
+
+            when(logParser.parse(any())).thenReturn(createParseResult(1));
+            when(statisticsCalculator.calculate(any()))
+                    .thenThrow(new ArithmeticException("division by zero"));
+
+            assertThatThrownBy(() -> service.analyze(file))
+                    .isInstanceOf(StatisticsCalculationException.class)
+                    .hasMessageContaining("통계 계산에 실패했습니다")
+                    .hasCauseInstanceOf(ArithmeticException.class);
+        }
+
+        @Test
+        @DisplayName("정상 분석 시 warnings가 비어있다")
+        void shouldHaveEmptyWarningsOnSuccess() throws Exception {
+            var file = mockFile();
+
+            when(logParser.parse(any())).thenReturn(createParseResult(1));
+            when(statisticsCalculator.calculate(any())).thenReturn(createStats(List.of()));
+
+            var result = service.analyze(file);
+
+            assertThat(result.getWarnings()).isEmpty();
         }
     }
 }

--- a/src/test/java/com/electricip/loganalyzer/application/AnalysisServiceTest.java
+++ b/src/test/java/com/electricip/loganalyzer/application/AnalysisServiceTest.java
@@ -372,38 +372,45 @@ class AnalysisServiceTest {
     class GracefulDegradationTest {
 
         @Test
-        @DisplayName("IP enrichment 외부 단계 실패 시 warning 포함 + 빈 ipDetails로 결과 반환")
+        @DisplayName("IpInfoClient 장애 시 warning 포함 + unknown ipDetails로 결과 반환")
         void shouldReturnResultWithWarningWhenIpEnrichmentFails() throws Exception {
             var file = mockFile();
-            // null item을 포함하면 topIps.stream().map(TopItem::item)에서 NPE 발생 → enrichIpInfo 전체 실패
-            // 대신 statisticsCalculator가 topIps에서 NPE를 유발하는 statistics를 반환하도록 구성
-            var normalStats = createStats(List.of(new AnalysisResult.TopItem("1.1.1.1", 100)));
+            var topIps = List.of(
+                    new AnalysisResult.TopItem("1.1.1.1", 100),
+                    new AnalysisResult.TopItem("2.2.2.2", 50));
 
-            when(logParser.parse(any())).thenReturn(createParseResult(1));
-            // statistics.topIps()가 null을 반환하는 mock Statistics를 사용하여 enrichIpInfo에서 NPE 유발
-            var brokenStats = mock(AnalysisResult.Statistics.class);
-            lenient().when(brokenStats.totalRequests()).thenReturn(100L);
-            when(brokenStats.topIps()).thenThrow(new RuntimeException("IP 목록 조회 실패"));
-            lenient().when(brokenStats.successCount()).thenReturn(90L);
-            lenient().when(brokenStats.redirectCount()).thenReturn(5L);
-            lenient().when(brokenStats.clientErrorCount()).thenReturn(3L);
-            lenient().when(brokenStats.serverErrorCount()).thenReturn(2L);
-            lenient().when(brokenStats.topPaths()).thenReturn(List.of());
-            lenient().when(brokenStats.topStatusCodes()).thenReturn(List.of());
-            lenient().when(brokenStats.methodStats()).thenReturn(Map.of());
-            lenient().when(brokenStats.avgResponseTime()).thenReturn(0.5);
-            lenient().when(brokenStats.avgSentBytes()).thenReturn(200.0);
-            lenient().when(brokenStats.totalTraffic()).thenReturn(20000L);
-
-            when(statisticsCalculator.calculate(any())).thenReturn(brokenStats);
+            when(logParser.parse(any())).thenReturn(createParseResult(2));
+            when(statisticsCalculator.calculate(any())).thenReturn(createStats(topIps));
+            // IpInfoClient가 예외를 던져 실제 외부 장애를 재현
+            when(ipInfoClient.getIpInfo(anyString()))
+                    .thenThrow(new RuntimeException("Connection refused"));
 
             var result = service.analyze(file);
 
             assertThat(result).isNotNull();
             assertThat(result.getStatistics().totalRequests()).isEqualTo(100);
-            assertThat(result.getIpDetails()).isEmpty();
+            // 실패한 IP는 unknown으로 fallback
+            assertThat(result.getIpDetails()).hasSize(2);
+            assertThat(result.getIpDetails().get("1.1.1.1").isValid()).isFalse();
+            assertThat(result.getIpDetails().get("2.2.2.2").isValid()).isFalse();
+            // warnings에 실패 정보 포함
             assertThat(result.getWarnings()).isNotEmpty();
-            assertThat(result.getWarnings().get(0)).contains("IP 정보 조회에 실패했습니다");
+            assertThat(result.getWarnings().get(0)).contains("일부 IP 정보 조회에 실패했습니다");
+        }
+
+        @Test
+        @DisplayName("statistics.topIps() 접근 실패 시 StatisticsCalculationException 발생")
+        void shouldThrowStatisticsCalculationExceptionWhenTopIpsAccessFails() throws Exception {
+            var file = mockFile();
+
+            when(logParser.parse(any())).thenReturn(createParseResult(1));
+            var brokenStats = mock(AnalysisResult.Statistics.class);
+            when(brokenStats.topIps()).thenThrow(new RuntimeException("통계 데이터 손상"));
+            when(statisticsCalculator.calculate(any())).thenReturn(brokenStats);
+
+            assertThatThrownBy(() -> service.analyze(file))
+                    .isInstanceOf(StatisticsCalculationException.class)
+                    .hasMessageContaining("통계 데이터 접근에 실패했습니다");
         }
 
         @Test

--- a/src/test/java/com/electricip/loganalyzer/domain/AnalysisResultTest.java
+++ b/src/test/java/com/electricip/loganalyzer/domain/AnalysisResultTest.java
@@ -179,6 +179,7 @@ class AnalysisResultTest {
                     null,
                     validStatistics(),
                     mutableMap,
+                    null,
                     null
             );
 
@@ -398,6 +399,7 @@ class AnalysisResultTest {
                     null,
                     validStatistics(),
                     null,
+                    null,
                     null
             );
 
@@ -416,6 +418,7 @@ class AnalysisResultTest {
                     LocalDateTime.now(),
                     null,
                     validStatistics(),
+                    null,
                     null,
                     stats
             );


### PR DESCRIPTION
## Summary
<!-- 이 PR이 무엇을 변경하는지 한 줄 요약 -->
통계 계산 실패와 IP enrichment 실패를 명확히 구분하여 처리하고,
분석 결과에 경고(warnings)를 포함할 수 있도록 분석 결과 및 응답 모델을 확장

## Context
<!-- 왜 이 변경이 필요한지 / 배경 -->
### Issue #18 
- Issue: #18 
### Background
- 기존에는 통계 계산 실패와 외부 IP enrichment 실패가 동일하게 처리되거나,
일부 실패가 조용히 무시되어 원인 파악이 어려웠음
- IP enrichment는 외부 의존성이므로 전체 분석 실패 대신 부분 실패 허용이 필요했음
- 반면 통계 계산 실패는 분석 결과 자체가 무의미하므로 명시적 실패 처리가 필요했음

## Changes
<!-- 변경 사항을 계층별로 간결하게 -->
### Domain
- `StatisticsCalculationException` 신규 추가
LogAnalyzerException 상속
errorCode: STATISTICS_CALCULATION_ERROR

- `AnalysisResult`
warnings 필드 추가
생성자에서 방어적 복사 적용

### Application
- `AnalysisService.analyze()`
통계 계산 실패 시 StatisticsCalculationException throw
IP enrichment 실패 시 빈 Map 반환 + warning 추가 (graceful degradation)

### API:
 - AnalysisResponse
warnings 필드 추가
AnalysisResult → Response 매핑 반영 

- GlobalExceptionHandler
StatisticsCalculationException → HTTP 500 응답 처리 추가

---

## Code Convention Checklist
> 본 PR은 프로젝트 코드 컨벤션을 기준으로 검토합니다.  
> 세부 기준은 `docs/CODE_CONVENTION.md`를 따릅니다.

### 1. 객체 생성 & 수명 관리
- [x] 생성 로직은 생성자 대신 **정적 팩터리 메서드** 또는 **빌더**로 캡슐화했다
- [x] 매개변수가 많은 객체는 **Builder 패턴**을 사용했다
- [x] 의존 객체는 **생성자 주입**으로 전달했다
- [ ] 자원 사용 시 **try-with-resources**를 적용했다

### 2. 불변성 & 스레드 안정성
- [x] 도메인 객체는 **불변(record / @Value)** 으로 설계했다
- [x] 내부 상태는 외부에서 수정할 수 없도록 보호했다
- [x] 동시 접근 가능 구조에는 **thread-safe 컬렉션**을 사용했다

### 3. 메서드 계약
- [x] public 메서드는 **매개변수 유효성 검사**를 수행한다
- [x] `null` 대신 **Optional 또는 빈 컬렉션**을 반환한다
- [x] 컬렉션/배열은 **방어적 복사** 또는 불변 래핑을 적용했다
- [x] 실패 케이스는 **Fail-Fast**로 드러난다

### 4. 계층 분리
- [x] Domain 레이어는 **외부 의존성(프레임워크/IO)** 이 없다
- [x] 외부 시스템 연동은 Infrastructure 레이어에 격리했다
- [x] Application 레이어는 오케스트레이션 책임만 가진다

### 5. 예외 & 로깅
- [ ] 예외 메시지는 **행동 가능한 정보**를 포함한다
- [ ] 성공/실패 로그 레벨을 구분했다
- [ ] 민감 정보는 로그에 남기지 않았다

---

## Behavior Change
<!-- 사용자/클라이언트 관점에서의 동작 변화 -->
### Before
 IP enrichment 실패 시 분석 결과가 불완전하거나 원인 파악이 어려움
통계 계산 실패가 명확히 구분되지 않음

### After
IP enrichment 실패 시 분석은 성공하되 warnings로 실패 정보 제공
통계 계산 실패 시 명시적인 예외로 분석 실패 처리
클라이언트는 분석 결과의 신뢰 수준을 warnings로 판단 가능

## Test
```bash
./gradlew test
./gradlew build
```
- IP enrichment 전체 실패 시 warnings 반환 테스트
- 통계 계산 실패 시 예외 발생 테스트
- 정상 케이스에서 warnings가 비어 있음을 검증하는 테스트 추가

## Risk & Rollback
### Risk
API 응답에 warnings 필드가 추가됨 (하위 호환성 영향 낮음)
통계 계산 실패 시 기존보다 더 엄격하게 실패 처리됨

### Rollback
StatisticsCalculationException 핸들러 및 warnings 필드 제거
AnalysisService의 graceful degradation 로직 이전 방식으로 복원