### PR TITLE
feat: application-level API rate limit 도입 및 예외 분리

### DIFF
--- a/src/main/java/com/electricip/loganalyzer/api/AnalysisController.java
+++ b/src/main/java/com/electricip/loganalyzer/api/AnalysisController.java
@@ -1,6 +1,7 @@
 package com.electricip.loganalyzer.api;
 
 import com.electricip.loganalyzer.application.AnalysisService;
+import com.electricip.loganalyzer.application.RateLimitService;
 import com.electricip.loganalyzer.domain.exception.AnalysisNotFoundException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +34,7 @@ import java.util.List;
 public class AnalysisController {
     
     private final AnalysisService analysisService;
+    private final RateLimitService rateLimitService;
     
     /**
      * 로그 파일 분석
@@ -47,19 +50,36 @@ public class AnalysisController {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "422", description = "파싱 에러 과다 (유효한 로그 없음)",
                     content = @Content(schema = @Schema(implementation = ParsingErrorResponse.class))),
+            @ApiResponse(responseCode = "429", description = "요청 한도 초과",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     public ResponseEntity<AnalysisIdResponse> analyze(
             @Parameter(description = "분석할 CSV 로그 파일", required = true)
-            @RequestParam("file") @NotNull(message = "파일은 필수입니다") MultipartFile file) {
-        
+            @RequestParam("file") @NotNull(message = "파일은 필수입니다") MultipartFile file,
+            HttpServletRequest request) {
+
+        String clientIp = getClientIp(request);
+        rateLimitService.checkRateLimit(clientIp);
+
         var result = analysisService.analyze(file);
-        
-        return ResponseEntity.ok(new AnalysisIdResponse(
-                result.getAnalysisId(),
-                "분석이 완료되었습니다"
-        ));
+
+        return ResponseEntity.ok()
+                .header("X-RateLimit-Remaining",
+                        String.valueOf(rateLimitService.getRemainingRequests(clientIp)))
+                .body(new AnalysisIdResponse(
+                        result.getAnalysisId(),
+                        "분석이 완료되었습니다"
+                ));
+    }
+
+    private String getClientIp(HttpServletRequest request) {
+        String xForwardedFor = request.getHeader("X-Forwarded-For");
+        if (xForwardedFor != null && !xForwardedFor.isBlank()) {
+            return xForwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
     }
     
     /**

--- a/src/main/java/com/electricip/loganalyzer/api/AnalysisController.java
+++ b/src/main/java/com/electricip/loganalyzer/api/AnalysisController.java
@@ -60,7 +60,7 @@ public class AnalysisController {
             @RequestParam("file") @NotNull(message = "파일은 필수입니다") MultipartFile file,
             HttpServletRequest request) {
 
-        String clientIp = getClientIp(request);
+        String clientIp = request.getRemoteAddr();
         rateLimitService.checkRateLimit(clientIp);
 
         var result = analysisService.analyze(file);
@@ -72,14 +72,6 @@ public class AnalysisController {
                         result.getAnalysisId(),
                         "분석이 완료되었습니다"
                 ));
-    }
-
-    private String getClientIp(HttpServletRequest request) {
-        String xForwardedFor = request.getHeader("X-Forwarded-For");
-        if (xForwardedFor != null && !xForwardedFor.isBlank()) {
-            return xForwardedFor.split(",")[0].trim();
-        }
-        return request.getRemoteAddr();
     }
     
     /**

--- a/src/main/java/com/electricip/loganalyzer/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/electricip/loganalyzer/api/GlobalExceptionHandler.java
@@ -196,11 +196,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleApiRateLimitExceeded(
             ApiRateLimitExceededException e, HttpServletRequest request) {
 
-        log.error("API rate limit 초과: {}", e.getMessage());
+        log.warn("애플리케이션 rate limit 초과: {}", e.getMessage());
 
         return ResponseEntity
                 .status(HttpStatus.TOO_MANY_REQUESTS)
-                .header("Retry-After", "60")
+                .header("Retry-After", String.valueOf(e.getRetryAfterSeconds()))
                 .body(ErrorResponse.of(
                         HttpStatus.TOO_MANY_REQUESTS,
                         e.getErrorCode(),
@@ -216,7 +216,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleRateLimitExceeded(
             RateLimitExceededException e, HttpServletRequest request) {
 
-        log.error("API rate limit 초과: {}", e.getMessage());
+        log.error("ipinfo rate limit 초과: {}", e.getMessage());
 
         return ResponseEntity
                 .status(HttpStatus.TOO_MANY_REQUESTS)

--- a/src/main/java/com/electricip/loganalyzer/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/electricip/loganalyzer/api/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.electricip.loganalyzer.api;
 
+import com.electricip.loganalyzer.domain.exception.ApiRateLimitExceededException;
 import com.electricip.loganalyzer.domain.exception.InvalidCsvFormatException;
 import com.electricip.loganalyzer.domain.exception.AnalysisNotFoundException;
 import com.electricip.loganalyzer.domain.exception.DuplicateAnalysisIdException;
@@ -182,6 +183,26 @@ public class GlobalExceptionHandler {
                 .status(HttpStatus.CONFLICT)
                 .body(ErrorResponse.of(
                         HttpStatus.CONFLICT,
+                        e.getErrorCode(),
+                        e.getMessage(),
+                        request.getRequestURI()
+                ));
+    }
+
+    /**
+     * ApiRateLimitExceededException 처리 → 429 + Retry-After
+     */
+    @ExceptionHandler(ApiRateLimitExceededException.class)
+    public ResponseEntity<ErrorResponse> handleApiRateLimitExceeded(
+            ApiRateLimitExceededException e, HttpServletRequest request) {
+
+        log.error("API rate limit 초과: {}", e.getMessage());
+
+        return ResponseEntity
+                .status(HttpStatus.TOO_MANY_REQUESTS)
+                .header("Retry-After", "60")
+                .body(ErrorResponse.of(
+                        HttpStatus.TOO_MANY_REQUESTS,
                         e.getErrorCode(),
                         e.getMessage(),
                         request.getRequestURI()

--- a/src/main/java/com/electricip/loganalyzer/application/RateLimitService.java
+++ b/src/main/java/com/electricip/loganalyzer/application/RateLimitService.java
@@ -7,13 +7,16 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * IP별 분당 요청 수를 제한하는 서비스
+ * IP별 요청 수를 제한하는 서비스
  */
 @Component
 public class RateLimitService {
+
+    private static final int MAX_TRACKED_IPS = 10_000;
 
     private final RateLimitProperties properties;
     private final Cache<String, AtomicInteger> requestCounts;
@@ -21,7 +24,8 @@ public class RateLimitService {
     public RateLimitService(RateLimitProperties properties) {
         this.properties = properties;
         this.requestCounts = Caffeine.newBuilder()
-                .expireAfterWrite(Duration.ofMinutes(1))
+                .expireAfterWrite(Duration.ofSeconds(properties.windowSeconds()))
+                .maximumSize(MAX_TRACKED_IPS)
                 .build();
     }
 
@@ -30,6 +34,8 @@ public class RateLimitService {
      * 한도 초과 시 {@link ApiRateLimitExceededException}을 던진다.
      */
     public void checkRateLimit(String clientIp) {
+        Objects.requireNonNull(clientIp, "clientIp는 null일 수 없습니다");
+
         if (!properties.enabled()) {
             return;
         }
@@ -39,8 +45,9 @@ public class RateLimitService {
 
         if (current > properties.maxRequestsPerMinute()) {
             throw new ApiRateLimitExceededException(
-                    String.format("IP %s의 요청이 분당 %d회 한도를 초과했습니다",
-                            clientIp, properties.maxRequestsPerMinute()));
+                    String.format("IP %s의 요청이 %d초 내 %d회 한도를 초과했습니다",
+                            clientIp, properties.windowSeconds(), properties.maxRequestsPerMinute()),
+                    properties.windowSeconds());
         }
     }
 
@@ -48,6 +55,8 @@ public class RateLimitService {
      * 해당 IP의 잔여 요청 수를 반환한다.
      */
     public int getRemainingRequests(String clientIp) {
+        Objects.requireNonNull(clientIp, "clientIp는 null일 수 없습니다");
+
         if (!properties.enabled()) {
             return properties.maxRequestsPerMinute();
         }

--- a/src/main/java/com/electricip/loganalyzer/application/RateLimitService.java
+++ b/src/main/java/com/electricip/loganalyzer/application/RateLimitService.java
@@ -1,0 +1,59 @@
+package com.electricip.loganalyzer.application;
+
+import com.electricip.loganalyzer.config.RateLimitProperties;
+import com.electricip.loganalyzer.domain.exception.ApiRateLimitExceededException;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * IP별 분당 요청 수를 제한하는 서비스
+ */
+@Component
+public class RateLimitService {
+
+    private final RateLimitProperties properties;
+    private final Cache<String, AtomicInteger> requestCounts;
+
+    public RateLimitService(RateLimitProperties properties) {
+        this.properties = properties;
+        this.requestCounts = Caffeine.newBuilder()
+                .expireAfterWrite(Duration.ofMinutes(1))
+                .build();
+    }
+
+    /**
+     * 요청 한도를 확인하고 카운트를 증가시킨다.
+     * 한도 초과 시 {@link ApiRateLimitExceededException}을 던진다.
+     */
+    public void checkRateLimit(String clientIp) {
+        if (!properties.enabled()) {
+            return;
+        }
+
+        AtomicInteger counter = requestCounts.get(clientIp, key -> new AtomicInteger(0));
+        int current = counter.incrementAndGet();
+
+        if (current > properties.maxRequestsPerMinute()) {
+            throw new ApiRateLimitExceededException(
+                    String.format("IP %s의 요청이 분당 %d회 한도를 초과했습니다",
+                            clientIp, properties.maxRequestsPerMinute()));
+        }
+    }
+
+    /**
+     * 해당 IP의 잔여 요청 수를 반환한다.
+     */
+    public int getRemainingRequests(String clientIp) {
+        if (!properties.enabled()) {
+            return properties.maxRequestsPerMinute();
+        }
+
+        AtomicInteger counter = requestCounts.getIfPresent(clientIp);
+        int used = (counter != null) ? counter.get() : 0;
+        return Math.max(0, properties.maxRequestsPerMinute() - used);
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/config/RateLimitProperties.java
+++ b/src/main/java/com/electricip/loganalyzer/config/RateLimitProperties.java
@@ -1,0 +1,24 @@
+package com.electricip.loganalyzer.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+/**
+ * Rate Limit 설정 프로퍼티
+ *
+ * @param maxRequestsPerMinute IP당 분당 최대 요청 수
+ * @param enabled              Rate Limit 활성화 여부
+ */
+@ConfigurationProperties(prefix = "rate-limit")
+public record RateLimitProperties(
+        @DefaultValue("10") int maxRequestsPerMinute,
+        @DefaultValue("true") boolean enabled
+) {
+
+    public RateLimitProperties {
+        if (maxRequestsPerMinute <= 0) {
+            throw new IllegalArgumentException(
+                    "maxRequestsPerMinute는 양수여야 합니다: " + maxRequestsPerMinute);
+        }
+    }
+}

--- a/src/main/java/com/electricip/loganalyzer/config/RateLimitProperties.java
+++ b/src/main/java/com/electricip/loganalyzer/config/RateLimitProperties.java
@@ -6,19 +6,25 @@ import org.springframework.boot.context.properties.bind.DefaultValue;
 /**
  * Rate Limit 설정 프로퍼티
  *
- * @param maxRequestsPerMinute IP당 분당 최대 요청 수
+ * @param maxRequestsPerMinute IP당 윈도우당 최대 요청 수
  * @param enabled              Rate Limit 활성화 여부
+ * @param windowSeconds        Rate Limit 윈도우 크기(초)
  */
 @ConfigurationProperties(prefix = "rate-limit")
 public record RateLimitProperties(
         @DefaultValue("10") int maxRequestsPerMinute,
-        @DefaultValue("true") boolean enabled
+        @DefaultValue("true") boolean enabled,
+        @DefaultValue("60") int windowSeconds
 ) {
 
     public RateLimitProperties {
         if (maxRequestsPerMinute <= 0) {
             throw new IllegalArgumentException(
                     "maxRequestsPerMinute는 양수여야 합니다: " + maxRequestsPerMinute);
+        }
+        if (windowSeconds <= 0) {
+            throw new IllegalArgumentException(
+                    "windowSeconds는 양수여야 합니다: " + windowSeconds);
         }
     }
 }

--- a/src/main/java/com/electricip/loganalyzer/domain/exception/ApiRateLimitExceededException.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/exception/ApiRateLimitExceededException.java
@@ -1,11 +1,18 @@
 package com.electricip.loganalyzer.domain.exception;
 
+import lombok.Getter;
+
 /**
  * 애플리케이션 수준의 API rate limit 초과 예외
  */
+@Getter
 public class ApiRateLimitExceededException extends LogAnalyzerException {
 
-    public ApiRateLimitExceededException(String message) {
+    private final int retryAfterSeconds;
+
+    public ApiRateLimitExceededException(String message, int retryAfterSeconds) {
         super("API_RATE_LIMIT_EXCEEDED", message);
+        this.retryAfterSeconds = retryAfterSeconds;
     }
+
 }

--- a/src/main/java/com/electricip/loganalyzer/domain/exception/ApiRateLimitExceededException.java
+++ b/src/main/java/com/electricip/loganalyzer/domain/exception/ApiRateLimitExceededException.java
@@ -1,0 +1,11 @@
+package com.electricip.loganalyzer.domain.exception;
+
+/**
+ * 애플리케이션 수준의 API rate limit 초과 예외
+ */
+public class ApiRateLimitExceededException extends LogAnalyzerException {
+
+    public ApiRateLimitExceededException(String message) {
+        super("API_RATE_LIMIT_EXCEEDED", message);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,11 @@ log-analysis:
   top-n-results: 10
   ip-enrichment-timeout-seconds: 5
 
+# Rate Limit 설정
+rate-limit:
+  max-requests-per-minute: 10
+  enabled: true
+
 # 로깅
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,7 @@ log-analysis:
 rate-limit:
   max-requests-per-minute: 10
   enabled: true
+  window-seconds: 60
 
 # 로깅
 logging:

--- a/src/test/java/com/electricip/loganalyzer/ConfigurationPropertiesBindingTest.java
+++ b/src/test/java/com/electricip/loganalyzer/ConfigurationPropertiesBindingTest.java
@@ -2,6 +2,7 @@ package com.electricip.loganalyzer;
 
 import com.electricip.loganalyzer.config.IpInfoProperties;
 import com.electricip.loganalyzer.config.LogAnalysisProperties;
+import com.electricip.loganalyzer.config.RateLimitProperties;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,12 +24,15 @@ import static org.assertj.core.api.Assertions.assertThat;
         "log-analysis.max-file-size-mb=25",
         "log-analysis.ip-enrichment-timeout-seconds=3",
         "ipinfo.base-url=https://test.ipinfo.io",
-        "ipinfo.token=test-token"
+        "ipinfo.token=test-token",
+        "rate-limit.max-requests-per-minute=20",
+        "rate-limit.enabled=false"
 })
 class ConfigurationPropertiesBindingTest {
 
     @Autowired private LogAnalysisProperties logAnalysisProperties;
     @Autowired private IpInfoProperties ipInfoProperties;
+    @Autowired private RateLimitProperties rateLimitProperties;
 
     @Test
     @DisplayName("LogAnalysisProperties가 @TestPropertySource 값으로 바인딩된다")
@@ -44,5 +48,12 @@ class ConfigurationPropertiesBindingTest {
     void ipInfoProperties_areBound() {
         assertThat(ipInfoProperties.baseUrl()).isEqualTo("https://test.ipinfo.io");
         assertThat(ipInfoProperties.token()).isEqualTo("test-token");
+    }
+
+    @Test
+    @DisplayName("RateLimitProperties가 @TestPropertySource 값으로 바인딩된다")
+    void rateLimitProperties_areBound() {
+        assertThat(rateLimitProperties.maxRequestsPerMinute()).isEqualTo(20);
+        assertThat(rateLimitProperties.enabled()).isFalse();
     }
 }

--- a/src/test/java/com/electricip/loganalyzer/ConfigurationPropertiesBindingTest.java
+++ b/src/test/java/com/electricip/loganalyzer/ConfigurationPropertiesBindingTest.java
@@ -26,7 +26,8 @@ import static org.assertj.core.api.Assertions.assertThat;
         "ipinfo.base-url=https://test.ipinfo.io",
         "ipinfo.token=test-token",
         "rate-limit.max-requests-per-minute=20",
-        "rate-limit.enabled=false"
+        "rate-limit.enabled=false",
+        "rate-limit.window-seconds=30"
 })
 class ConfigurationPropertiesBindingTest {
 
@@ -55,5 +56,6 @@ class ConfigurationPropertiesBindingTest {
     void rateLimitProperties_areBound() {
         assertThat(rateLimitProperties.maxRequestsPerMinute()).isEqualTo(20);
         assertThat(rateLimitProperties.enabled()).isFalse();
+        assertThat(rateLimitProperties.windowSeconds()).isEqualTo(30);
     }
 }

--- a/src/test/java/com/electricip/loganalyzer/api/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/electricip/loganalyzer/api/GlobalExceptionHandlerTest.java
@@ -1,5 +1,6 @@
 package com.electricip.loganalyzer.api;
 
+import com.electricip.loganalyzer.domain.exception.ApiRateLimitExceededException;
 import com.electricip.loganalyzer.domain.exception.InvalidCsvFormatException;
 import com.electricip.loganalyzer.domain.ParseError;
 import com.electricip.loganalyzer.domain.exception.AnalysisNotFoundException;
@@ -185,7 +186,25 @@ class GlobalExceptionHandlerTest {
     }
 
     @Nested
-    @DisplayName("RateLimitExceededException 핸들러")
+    @DisplayName("ApiRateLimitExceededException 핸들러")
+    class ApiRateLimitTest {
+
+        @Test
+        @DisplayName("429 Too Many Requests로 응답하며 Retry-After 헤더를 포함한다")
+        void shouldReturn429WithRetryAfter() {
+            var ex = new ApiRateLimitExceededException("요청 한도 초과");
+
+            var response = handler.handleApiRateLimitExceeded(ex, request);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().errorCode()).isEqualTo("API_RATE_LIMIT_EXCEEDED");
+            assertThat(response.getHeaders().getFirst("Retry-After")).isEqualTo("60");
+        }
+    }
+
+    @Nested
+    @DisplayName("RateLimitExceededException 핸들러 (ipinfo)")
     class RateLimitTest {
 
         @Test

--- a/src/test/java/com/electricip/loganalyzer/api/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/electricip/loganalyzer/api/GlobalExceptionHandlerTest.java
@@ -192,7 +192,7 @@ class GlobalExceptionHandlerTest {
         @Test
         @DisplayName("429 Too Many Requests로 응답하며 Retry-After 헤더를 포함한다")
         void shouldReturn429WithRetryAfter() {
-            var ex = new ApiRateLimitExceededException("요청 한도 초과");
+            var ex = new ApiRateLimitExceededException("요청 한도 초과", 60);
 
             var response = handler.handleApiRateLimitExceeded(ex, request);
 

--- a/src/test/java/com/electricip/loganalyzer/application/RateLimitServiceTest.java
+++ b/src/test/java/com/electricip/loganalyzer/application/RateLimitServiceTest.java
@@ -1,0 +1,122 @@
+package com.electricip.loganalyzer.application;
+
+import com.electricip.loganalyzer.config.RateLimitProperties;
+import com.electricip.loganalyzer.domain.exception.ApiRateLimitExceededException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RateLimitServiceTest {
+
+    @Nested
+    @DisplayName("checkRateLimit")
+    class CheckRateLimit {
+
+        @Test
+        @DisplayName("한도 내 요청은 정상 통과한다")
+        void shouldPassWithinLimit() {
+            var service = createService(5, true);
+
+            for (int i = 0; i < 5; i++) {
+                service.checkRateLimit("192.168.1.1");
+            }
+        }
+
+        @Test
+        @DisplayName("한도 초과 시 ApiRateLimitExceededException이 발생한다")
+        void shouldThrowWhenLimitExceeded() {
+            var service = createService(3, true);
+
+            for (int i = 0; i < 3; i++) {
+                service.checkRateLimit("192.168.1.1");
+            }
+
+            assertThatThrownBy(() -> service.checkRateLimit("192.168.1.1"))
+                    .isInstanceOf(ApiRateLimitExceededException.class)
+                    .hasMessageContaining("한도를 초과");
+        }
+
+        @Test
+        @DisplayName("enabled=false이면 항상 통과한다")
+        void shouldAlwaysPassWhenDisabled() {
+            var service = createService(1, false);
+
+            for (int i = 0; i < 100; i++) {
+                service.checkRateLimit("192.168.1.1");
+            }
+        }
+
+        @Test
+        @DisplayName("IP별로 독립적으로 카운트된다")
+        void shouldCountIndependentlyPerIp() {
+            var service = createService(2, true);
+
+            service.checkRateLimit("192.168.1.1");
+            service.checkRateLimit("192.168.1.1");
+
+            // 다른 IP는 별도 카운트
+            service.checkRateLimit("192.168.1.2");
+            service.checkRateLimit("192.168.1.2");
+
+            // 첫 번째 IP는 초과
+            assertThatThrownBy(() -> service.checkRateLimit("192.168.1.1"))
+                    .isInstanceOf(ApiRateLimitExceededException.class);
+
+            // 두 번째 IP도 초과
+            assertThatThrownBy(() -> service.checkRateLimit("192.168.1.2"))
+                    .isInstanceOf(ApiRateLimitExceededException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getRemainingRequests")
+    class GetRemainingRequests {
+
+        @Test
+        @DisplayName("요청 전에는 최대 한도를 반환한다")
+        void shouldReturnMaxBeforeAnyRequest() {
+            var service = createService(10, true);
+
+            assertThat(service.getRemainingRequests("192.168.1.1")).isEqualTo(10);
+        }
+
+        @Test
+        @DisplayName("요청 후 정확한 잔여 수를 반환한다")
+        void shouldReturnCorrectRemainingAfterRequests() {
+            var service = createService(5, true);
+
+            service.checkRateLimit("192.168.1.1");
+            service.checkRateLimit("192.168.1.1");
+
+            assertThat(service.getRemainingRequests("192.168.1.1")).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("한도 초과 후 0을 반환한다")
+        void shouldReturnZeroWhenExceeded() {
+            var service = createService(2, true);
+
+            service.checkRateLimit("192.168.1.1");
+            service.checkRateLimit("192.168.1.1");
+
+            assertThat(service.getRemainingRequests("192.168.1.1")).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("enabled=false이면 최대 한도를 반환한다")
+        void shouldReturnMaxWhenDisabled() {
+            var service = createService(10, false);
+
+            service.checkRateLimit("192.168.1.1");
+
+            assertThat(service.getRemainingRequests("192.168.1.1")).isEqualTo(10);
+        }
+    }
+
+    private RateLimitService createService(int maxRequests, boolean enabled) {
+        return new RateLimitService(new RateLimitProperties(maxRequests, enabled));
+    }
+}

--- a/src/test/java/com/electricip/loganalyzer/application/RateLimitServiceTest.java
+++ b/src/test/java/com/electricip/loganalyzer/application/RateLimitServiceTest.java
@@ -16,6 +16,16 @@ class RateLimitServiceTest {
     class CheckRateLimit {
 
         @Test
+        @DisplayName("clientIp가 null이면 NullPointerException이 발생한다")
+        void shouldRejectNullClientIp() {
+            var service = createService(5, true);
+
+            assertThatThrownBy(() -> service.checkRateLimit(null))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("clientIp");
+        }
+
+        @Test
         @DisplayName("한도 내 요청은 정상 통과한다")
         void shouldPassWithinLimit() {
             var service = createService(5, true);
@@ -36,7 +46,10 @@ class RateLimitServiceTest {
 
             assertThatThrownBy(() -> service.checkRateLimit("192.168.1.1"))
                     .isInstanceOf(ApiRateLimitExceededException.class)
-                    .hasMessageContaining("한도를 초과");
+                    .hasMessageContaining("한도를 초과")
+                    .satisfies(ex -> assertThat(
+                            ((ApiRateLimitExceededException) ex).getRetryAfterSeconds())
+                            .isEqualTo(60));
         }
 
         @Test
@@ -117,6 +130,6 @@ class RateLimitServiceTest {
     }
 
     private RateLimitService createService(int maxRequests, boolean enabled) {
-        return new RateLimitService(new RateLimitProperties(maxRequests, enabled));
+        return new RateLimitService(new RateLimitProperties(maxRequests, enabled, 60));
     }
 }


### PR DESCRIPTION
## Summary
<!-- 이 PR이 무엇을 변경하는지 한 줄 요약 -->
본 PR은 외부 API rate limit과 서비스(application) 레벨 rate limit을 명확히 분리하고,
IP 기반 요청 제한을 적용하기 위한 인프라를 도입
- 외부 시스템(ipinfo API)의 rate limit 예외와
우리 서비스의 요청 제한 예외를 의미적으로 분리
- IP 단위 요청 수를 관리하는 RateLimitService 추가
- Controller 단에서 application-level rate limit을 명시적으로 검증

## Context
<!-- 왜 이 변경이 필요한지 / 배경 -->
- Issue: #19 
- Background:
1. 무제한 요청 가능
2. 동일 IP의 반복 요청

## Changes
<!-- 변경 사항을 계층별로 간결하게 -->
### 1. 예외 설계 분리
ApiRateLimitExceededException 신규 추가
- 위치: domain.exception
- LogAnalyzerException 상속
- errorCode: API_RATE_LIMIT_EXCEEDED

기존 infrastructure.client.RateLimitExceededException
- 외부 API(ipinfo) 전용 예외로 유지

### 2. RateLimitService 도입
- application/RateLimitService
- Caffeine Cache 기반 IP별 요청 수 관리
- enabled=false 설정 시 rate limit 비활성화 (항상 통과)

### . Controller 적용

- AnalysisController에서 요청 처리 전 RateLimitService.checkRateLimit() 호출
- application-level rate limit 위반 시 즉시 실패(Fail-Fast)

---

## Code Convention Checklist
> 본 PR은 프로젝트 코드 컨벤션을 기준으로 검토합니다.  
> 세부 기준은 `docs/CODE_CONVENTION.md`를 따릅니다.

### 1. 객체 생성 & 수명 관리
- [x] 생성 로직은 생성자 대신 **정적 팩터리 메서드** 또는 **빌더**로 캡슐화했다
- [x] 매개변수가 많은 객체는 **Builder 패턴**을 사용했다
- [x] 의존 객체는 **생성자 주입**으로 전달했다
- [ ] 자원 사용 시 **try-with-resources**를 적용했다

### 2. 불변성 & 스레드 안정성
- [x] 도메인 객체는 **불변(record / @Value)** 으로 설계했다
- [x] 내부 상태는 외부에서 수정할 수 없도록 보호했다
- [x] 동시 접근 가능 구조에는 **thread-safe 컬렉션**을 사용했다

### 3. 메서드 계약
- [x] public 메서드는 **매개변수 유효성 검사**를 수행한다
- [x] `null` 대신 **Optional 또는 빈 컬렉션**을 반환한다
- [x] 컬렉션/배열은 **방어적 복사** 또는 불변 래핑을 적용했다
- [ ] 실패 케이스는 **Fail-Fast**로 드러난다

### 4. 계층 분리
- [x] Domain 레이어는 **외부 의존성(프레임워크/IO)** 이 없다
- [x] 외부 시스템 연동은 Infrastructure 레이어에 격리했다
- [x] Application 레이어는 오케스트레이션 책임만 가진다

### 5. 예외 & 로깅
- [ ] 예외 메시지는 **행동 가능한 정보**를 포함한다
- [ ] 성공/실패 로그 레벨을 구분했다
- [ ] 민감 정보는 로그에 남기지 않았다

---

## Behavior Change
<!-- 사용자/클라이언트 관점에서의 동작 변화 -->
- Before: 외부 ipinfo API rate limit 예외와 서비스 요청 제한이 개념적으로 분리되지 않음
application-level 요청 제한 없음
- After: 서비스 요청 제한(application-level rate limit) 명확히 도입
외부 API rate limit과 내부 rate limit 예외가 책임별로 분리됨
IP 기반 요청 제한 초과 시 명시적인 에러 코드 반환

## Test
```bash
./gradlew test
./gradlew build
```

## Risk & Rollback
- Risk:
  - IP 기반 rate limit 로직이 잘못 설정될 경우 정상 사용자가 일시적으로 요청 제한에 걸릴 수 있음
  - Cache TTL 또는 허용 요청 수 설정 오류 시 예상보다 빠르게 rate limit이 동작할 가능성
  - RateLimitService가 Controller 진입 시점에 동작하므로, 설정 오류가 전체 분석 API 가용성에 직접적인 영향을 줄 수 있음

- Rollback:
  - `rate-limit.enabled=false` 설정을 통해 즉시 비활성화 가능
  - 필요 시 `AnalysisController`의 rate limit 체크 호출 제거하여 기존 동작으로 복구
  - 신규 추가된 `ApiRateLimitExceededException` 및 `RateLimitService` 제거 시 기존 외부 API rate limit 처리 로직에는 영향 없음